### PR TITLE
fix(invitations): normalize emails and prevent duplicate invitations

### DIFF
--- a/apps/web/src/app/invitations/[data]/_components/getInvitationData.integration.ts
+++ b/apps/web/src/app/invitations/[data]/_components/getInvitationData.integration.ts
@@ -1,0 +1,191 @@
+import { resetFixtureUser } from '@app/fixtures/resetFixtureUser'
+import { seedStructures } from '@app/fixtures/structures'
+import {
+  coordinateurInscritAvecTout,
+  coordinateurInscritAvecToutCoordinateurId,
+} from '@app/fixtures/users/coordinateurInscritAvecTout'
+import { prismaClient } from '@app/web/prismaClient'
+import { getInvitationData } from './getInvitationData'
+
+describe('getInvitationData', () => {
+  const testEmail = 'test-get-invitation@example.com'
+
+  beforeAll(async () => {
+    await seedStructures(prismaClient)
+    await resetFixtureUser(coordinateurInscritAvecTout, false)
+  })
+
+  beforeEach(async () => {
+    await prismaClient.invitationEquipe.deleteMany({
+      where: { coordinateurId: coordinateurInscritAvecToutCoordinateurId },
+    })
+  })
+
+  afterAll(async () => {
+    await prismaClient.invitationEquipe.deleteMany({
+      where: { coordinateurId: coordinateurInscritAvecToutCoordinateurId },
+    })
+  })
+
+  describe('case-insensitive email lookup', () => {
+    it('should find pending invitation with uppercase email when stored lowercase', async () => {
+      await prismaClient.invitationEquipe.create({
+        data: {
+          email: testEmail.toLowerCase(),
+          coordinateurId: coordinateurInscritAvecToutCoordinateurId,
+        },
+      })
+
+      const result = await getInvitationData({
+        email: testEmail.toUpperCase(),
+        coordinateurId: coordinateurInscritAvecToutCoordinateurId,
+      })
+
+      expect(result).not.toBeNull()
+      expect(result?.coordinateur).toBeDefined()
+    })
+
+    it('should find pending invitation with lowercase email when stored uppercase', async () => {
+      await prismaClient.invitationEquipe.create({
+        data: {
+          email: testEmail.toUpperCase(),
+          coordinateurId: coordinateurInscritAvecToutCoordinateurId,
+        },
+      })
+
+      const result = await getInvitationData({
+        email: testEmail.toLowerCase(),
+        coordinateurId: coordinateurInscritAvecToutCoordinateurId,
+      })
+
+      expect(result).not.toBeNull()
+    })
+
+    it('should find pending invitation with mixed case email', async () => {
+      await prismaClient.invitationEquipe.create({
+        data: {
+          email: 'TeSt-GeT-InViTaTiOn@ExAmPlE.cOm',
+          coordinateurId: coordinateurInscritAvecToutCoordinateurId,
+        },
+      })
+
+      const result = await getInvitationData({
+        email: 'test-get-invitation@example.com',
+        coordinateurId: coordinateurInscritAvecToutCoordinateurId,
+      })
+
+      expect(result).not.toBeNull()
+    })
+  })
+
+  describe('invitation status filtering', () => {
+    it('should not find accepted invitation', async () => {
+      await prismaClient.invitationEquipe.create({
+        data: {
+          email: testEmail,
+          coordinateurId: coordinateurInscritAvecToutCoordinateurId,
+          acceptee: new Date(),
+        },
+      })
+
+      const result = await getInvitationData({
+        email: testEmail,
+        coordinateurId: coordinateurInscritAvecToutCoordinateurId,
+      })
+
+      expect(result).toBeNull()
+    })
+
+    it('should not find refused invitation', async () => {
+      await prismaClient.invitationEquipe.create({
+        data: {
+          email: testEmail,
+          coordinateurId: coordinateurInscritAvecToutCoordinateurId,
+          refusee: new Date(),
+        },
+      })
+
+      const result = await getInvitationData({
+        email: testEmail,
+        coordinateurId: coordinateurInscritAvecToutCoordinateurId,
+      })
+
+      expect(result).toBeNull()
+    })
+
+    it('should find pending invitation (acceptee and refusee both null)', async () => {
+      await prismaClient.invitationEquipe.create({
+        data: {
+          email: testEmail,
+          coordinateurId: coordinateurInscritAvecToutCoordinateurId,
+          acceptee: null,
+          refusee: null,
+        },
+      })
+
+      const result = await getInvitationData({
+        email: testEmail,
+        coordinateurId: coordinateurInscritAvecToutCoordinateurId,
+      })
+
+      expect(result).not.toBeNull()
+    })
+  })
+
+  describe('invitation not found', () => {
+    it('should return null when invitation does not exist', async () => {
+      const result = await getInvitationData({
+        email: 'non-existent@example.com',
+        coordinateurId: coordinateurInscritAvecToutCoordinateurId,
+      })
+
+      expect(result).toBeNull()
+    })
+
+    it('should return null when coordinateurId does not match', async () => {
+      await prismaClient.invitationEquipe.create({
+        data: {
+          email: testEmail,
+          coordinateurId: coordinateurInscritAvecToutCoordinateurId,
+        },
+      })
+
+      const result = await getInvitationData({
+        email: testEmail,
+        coordinateurId: '00000000-0000-0000-0000-000000000000',
+      })
+
+      expect(result).toBeNull()
+    })
+  })
+
+  describe('returned data', () => {
+    it('should return coordinateur user data and mediateursCoordonnes count', async () => {
+      await prismaClient.invitationEquipe.create({
+        data: {
+          email: testEmail,
+          coordinateurId: coordinateurInscritAvecToutCoordinateurId,
+        },
+      })
+
+      const result = await getInvitationData({
+        email: testEmail,
+        coordinateurId: coordinateurInscritAvecToutCoordinateurId,
+      })
+
+      expect(result).toMatchObject({
+        coordinateur: {
+          user: {
+            name: expect.any(String),
+            firstName: expect.any(String),
+            lastName: expect.any(String),
+            email: expect.any(String),
+          },
+          _count: {
+            mediateursCoordonnes: expect.any(Number),
+          },
+        },
+      })
+    })
+  })
+})

--- a/apps/web/src/app/invitations/[data]/_components/getInvitationData.ts
+++ b/apps/web/src/app/invitations/[data]/_components/getInvitationData.ts
@@ -4,7 +4,8 @@ import { prismaClient } from '@app/web/prismaClient'
 export const getInvitationData = (invitation: Invitation) =>
   prismaClient.invitationEquipe.findFirst({
     where: {
-      ...invitation,
+      email: { equals: invitation.email, mode: 'insensitive' },
+      coordinateurId: invitation.coordinateurId,
       acceptee: null,
       refusee: null,
     },

--- a/apps/web/src/mediateurs/emailComparison.spec.ts
+++ b/apps/web/src/mediateurs/emailComparison.spec.ts
@@ -1,0 +1,99 @@
+import {
+  isAlreadyInvited,
+  isAlreadyTeamMember,
+  isEmailMatch,
+  normalizeEmail,
+} from './emailComparison'
+
+describe('emailComparison', () => {
+  describe('isEmailMatch', () => {
+    it('should return true for identical emails', () => {
+      expect(isEmailMatch('test@example.com', 'test@example.com')).toBe(true)
+    })
+
+    it('should return true for emails with different cases', () => {
+      expect(isEmailMatch('TEST@EXAMPLE.COM', 'test@example.com')).toBe(true)
+      expect(isEmailMatch('test@example.com', 'TEST@EXAMPLE.COM')).toBe(true)
+      expect(isEmailMatch('TeSt@ExAmPlE.cOm', 'test@example.com')).toBe(true)
+    })
+
+    it('should return false for different emails', () => {
+      expect(isEmailMatch('test1@example.com', 'test2@example.com')).toBe(false)
+      expect(isEmailMatch('test@example.com', 'test@example.fr')).toBe(false)
+    })
+  })
+
+  describe('isAlreadyInvited', () => {
+    const existingInvitations = [
+      { email: 'invited1@example.com' },
+      { email: 'invited2@example.com' },
+      { email: 'UPPERCASE@example.com' },
+    ]
+
+    it('should return true when email exists in invitations (exact match)', () => {
+      expect(
+        isAlreadyInvited('invited1@example.com', existingInvitations),
+      ).toBe(true)
+    })
+
+    it('should return true when email exists with different case', () => {
+      expect(
+        isAlreadyInvited('INVITED1@EXAMPLE.COM', existingInvitations),
+      ).toBe(true)
+      expect(
+        isAlreadyInvited('uppercase@example.com', existingInvitations),
+      ).toBe(true)
+    })
+
+    it('should return false when email does not exist', () => {
+      expect(isAlreadyInvited('new@example.com', existingInvitations)).toBe(
+        false,
+      )
+    })
+
+    it('should return false for empty invitations list', () => {
+      expect(isAlreadyInvited('test@example.com', [])).toBe(false)
+    })
+  })
+
+  describe('isAlreadyTeamMember', () => {
+    const teamMembers = [
+      { mediateur: { user: { email: 'member1@example.com' } } },
+      { mediateur: { user: { email: 'member2@example.com' } } },
+      { mediateur: { user: { email: 'UPPERCASE.MEMBER@example.com' } } },
+    ]
+
+    it('should return true when email exists in team members (exact match)', () => {
+      expect(isAlreadyTeamMember('member1@example.com', teamMembers)).toBe(true)
+    })
+
+    it('should return true when email exists with different case', () => {
+      expect(isAlreadyTeamMember('MEMBER1@EXAMPLE.COM', teamMembers)).toBe(true)
+      expect(
+        isAlreadyTeamMember('uppercase.member@example.com', teamMembers),
+      ).toBe(true)
+    })
+
+    it('should return false when email does not exist', () => {
+      expect(isAlreadyTeamMember('new@example.com', teamMembers)).toBe(false)
+    })
+
+    it('should return false for empty team members list', () => {
+      expect(isAlreadyTeamMember('test@example.com', [])).toBe(false)
+    })
+  })
+
+  describe('normalizeEmail', () => {
+    it('should convert email to lowercase', () => {
+      expect(normalizeEmail('TEST@EXAMPLE.COM')).toBe('test@example.com')
+    })
+
+    it('should handle mixed case', () => {
+      expect(normalizeEmail('TeSt@ExAmPlE.cOm')).toBe('test@example.com')
+    })
+
+    it('should not change already lowercase email', () => {
+      expect(normalizeEmail('test@example.com')).toBe('test@example.com')
+    })
+  })
+})

--- a/apps/web/src/mediateurs/emailComparison.ts
+++ b/apps/web/src/mediateurs/emailComparison.ts
@@ -1,0 +1,18 @@
+export const isEmailMatch = (email1: string, email2: string): boolean =>
+  email1.toLowerCase() === email2.toLowerCase()
+
+export const isAlreadyInvited = (
+  email: string,
+  existingInvitations: { email: string }[],
+): boolean =>
+  existingInvitations.some((invitation) =>
+    isEmailMatch(invitation.email, email),
+  )
+
+export const isAlreadyTeamMember = (
+  email: string,
+  teamMembers: { mediateur: { user: { email: string } } }[],
+): boolean =>
+  teamMembers.some(({ mediateur }) => isEmailMatch(mediateur.user.email, email))
+
+export const normalizeEmail = (email: string): string => email.toLowerCase()

--- a/apps/web/src/mediateurs/findInvitationFrom.integration.ts
+++ b/apps/web/src/mediateurs/findInvitationFrom.integration.ts
@@ -1,0 +1,128 @@
+import { resetFixtureUser } from '@app/fixtures/resetFixtureUser'
+import { seedStructures } from '@app/fixtures/structures'
+import {
+  coordinateurInscritAvecTout,
+  coordinateurInscritAvecToutCoordinateurId,
+} from '@app/fixtures/users/coordinateurInscritAvecTout'
+import { prismaClient } from '@app/web/prismaClient'
+import { findInvitationFrom } from './findInvitationFrom'
+
+describe('findInvitationFrom', () => {
+  const testEmail = 'test-invitation@example.com'
+
+  beforeAll(async () => {
+    await seedStructures(prismaClient)
+    await resetFixtureUser(coordinateurInscritAvecTout, false)
+  })
+
+  beforeEach(async () => {
+    await prismaClient.invitationEquipe.deleteMany({
+      where: { coordinateurId: coordinateurInscritAvecToutCoordinateurId },
+    })
+  })
+
+  afterAll(async () => {
+    await prismaClient.invitationEquipe.deleteMany({
+      where: { coordinateurId: coordinateurInscritAvecToutCoordinateurId },
+    })
+  })
+
+  describe('case-insensitive email lookup', () => {
+    it('should find invitation when searching with uppercase email and stored lowercase', async () => {
+      await prismaClient.invitationEquipe.create({
+        data: {
+          email: testEmail.toLowerCase(),
+          coordinateurId: coordinateurInscritAvecToutCoordinateurId,
+        },
+      })
+
+      const result = await findInvitationFrom(
+        coordinateurInscritAvecToutCoordinateurId,
+      )(testEmail.toUpperCase())
+
+      expect(result).not.toBeNull()
+      expect(result?.email).toBe(testEmail.toLowerCase())
+    })
+
+    it('should find invitation when searching with lowercase email and stored uppercase', async () => {
+      await prismaClient.invitationEquipe.create({
+        data: {
+          email: testEmail.toUpperCase(),
+          coordinateurId: coordinateurInscritAvecToutCoordinateurId,
+        },
+      })
+
+      const result = await findInvitationFrom(
+        coordinateurInscritAvecToutCoordinateurId,
+      )(testEmail.toLowerCase())
+
+      expect(result).not.toBeNull()
+      expect(result?.email).toBe(testEmail.toUpperCase())
+    })
+
+    it('should find invitation when searching with mixed case email', async () => {
+      await prismaClient.invitationEquipe.create({
+        data: {
+          email: 'TeSt-InViTaTiOn@ExAmPlE.cOm',
+          coordinateurId: coordinateurInscritAvecToutCoordinateurId,
+        },
+      })
+
+      const result = await findInvitationFrom(
+        coordinateurInscritAvecToutCoordinateurId,
+      )('test-invitation@example.com')
+
+      expect(result).not.toBeNull()
+    })
+  })
+
+  describe('invitation not found', () => {
+    it('should return null when invitation does not exist', async () => {
+      const result = await findInvitationFrom(
+        coordinateurInscritAvecToutCoordinateurId,
+      )('non-existent@example.com')
+
+      expect(result).toBeNull()
+    })
+
+    it('should return null when invitation exists for different coordinateur', async () => {
+      await prismaClient.invitationEquipe.create({
+        data: {
+          email: testEmail,
+          coordinateurId: coordinateurInscritAvecToutCoordinateurId,
+        },
+      })
+
+      const result = await findInvitationFrom(
+        '00000000-0000-0000-0000-000000000000',
+      )(testEmail)
+
+      expect(result).toBeNull()
+    })
+  })
+
+  describe('returned data', () => {
+    it('should return invitation with coordinateur and mediateurInvite data', async () => {
+      await prismaClient.invitationEquipe.create({
+        data: {
+          email: testEmail,
+          coordinateurId: coordinateurInscritAvecToutCoordinateurId,
+        },
+      })
+
+      const result = await findInvitationFrom(
+        coordinateurInscritAvecToutCoordinateurId,
+      )(testEmail)
+
+      expect(result).toMatchObject({
+        email: testEmail,
+        coordinateurId: coordinateurInscritAvecToutCoordinateurId,
+        coordinateur: {
+          user: {
+            email: expect.any(String),
+          },
+        },
+      })
+    })
+  })
+})

--- a/apps/web/src/mediateurs/findInvitationFrom.ts
+++ b/apps/web/src/mediateurs/findInvitationFrom.ts
@@ -4,7 +4,7 @@ export const findInvitationFrom =
   (coordinateurId: string) => async (email: string) =>
     prismaClient.invitationEquipe.findFirst({
       where: {
-        email,
+        email: { equals: email, mode: 'insensitive' },
         coordinateurId,
       },
       select: {

--- a/apps/web/src/mediateurs/inviteToJoinTeamOf.ts
+++ b/apps/web/src/mediateurs/inviteToJoinTeamOf.ts
@@ -15,7 +15,7 @@ const withInvitationFrom =
 export const inviteToJoinTeamOf =
   (user: CoordinateurUser) =>
   async (members: { email: string; mediateurId?: string }[]) => {
-    const mediateurs = await prismaClient.invitationEquipe.findMany({
+    const existingInvitations = await prismaClient.invitationEquipe.findMany({
       where: {
         mediateurId: {
           in: user.coordinateur.mediateursCoordonnes.map(
@@ -26,15 +26,40 @@ export const inviteToJoinTeamOf =
       select: { email: true },
     })
 
+    const existingTeamMembers = await prismaClient.mediateurCoordonne.findMany({
+      where: {
+        coordinateurId: user.coordinateur.id,
+        suppression: null,
+      },
+      select: {
+        mediateur: {
+          select: {
+            user: {
+              select: { email: true },
+            },
+          },
+        },
+      },
+    })
+
+    const isAlreadyInvited = (email: string) =>
+      existingInvitations.some(
+        (invitation) => invitation.email.toLowerCase() === email.toLowerCase(),
+      )
+
+    const isAlreadyTeamMember = (email: string) =>
+      existingTeamMembers.some(
+        ({ mediateur }) =>
+          mediateur.user.email.toLowerCase() === email.toLowerCase(),
+      )
+
     const invitations = members
-      .filter((member) =>
-        mediateurs.every(
-          (mediateur) =>
-            mediateur.email.toLowerCase() !== member.email.toLowerCase(),
-        ),
+      .filter(
+        (member) =>
+          !isAlreadyInvited(member.email) && !isAlreadyTeamMember(member.email),
       )
       .map((member) => ({
-        email: member.email,
+        email: member.email.toLowerCase(),
         coordinateurId: user.coordinateur.id,
         acceptee: null,
         refusee: null,

--- a/apps/web/src/mediateurs/inviteToJoinTeamOf.ts
+++ b/apps/web/src/mediateurs/inviteToJoinTeamOf.ts
@@ -1,6 +1,11 @@
 import type { CoordinateurUser } from '@app/web/auth/userTypeGuards'
 import { createInvitationUrl } from '@app/web/features/invitation/createInvitationUrl'
 import { prismaClient } from '@app/web/prismaClient'
+import {
+  isAlreadyInvited,
+  isAlreadyTeamMember,
+  normalizeEmail,
+} from './emailComparison'
 import { sendInviteMediateurEmail } from './sendInviteMediateurEmail'
 import { sendInviteNewMediateurEmail } from './sendInviteNewMediateurEmail'
 
@@ -42,24 +47,14 @@ export const inviteToJoinTeamOf =
       },
     })
 
-    const isAlreadyInvited = (email: string) =>
-      existingInvitations.some(
-        (invitation) => invitation.email.toLowerCase() === email.toLowerCase(),
-      )
-
-    const isAlreadyTeamMember = (email: string) =>
-      existingTeamMembers.some(
-        ({ mediateur }) =>
-          mediateur.user.email.toLowerCase() === email.toLowerCase(),
-      )
-
     const invitations = members
       .filter(
         (member) =>
-          !isAlreadyInvited(member.email) && !isAlreadyTeamMember(member.email),
+          !isAlreadyInvited(member.email, existingInvitations) &&
+          !isAlreadyTeamMember(member.email, existingTeamMembers),
       )
       .map((member) => ({
-        email: member.email.toLowerCase(),
+        email: normalizeEmail(member.email),
         coordinateurId: user.coordinateur.id,
         acceptee: null,
         refusee: null,


### PR DESCRIPTION
- Normalize email to lowercase when creating invitations
- Make invitation lookups case-insensitive
- Prevent inviting someone who is already a team member