### PR TITLE
fix: filter soft-deleted records in mediateursCoordonnes queries

### DIFF
--- a/apps/web/src/features/inscription/getMediateursCoordonnesForInscription.ts
+++ b/apps/web/src/features/inscription/getMediateursCoordonnesForInscription.ts
@@ -10,6 +10,7 @@ export const getMediateursCoordonnesForInscription = async ({
     select: {
       id: true,
       mediateursCoordonnes: {
+        where: { suppression: null },
         select: {
           id: true,
         },

--- a/apps/web/src/features/utilisateurs/use-cases/filter/db/actif-filter.ts
+++ b/apps/web/src/features/utilisateurs/use-cases/filter/db/actif-filter.ts
@@ -15,7 +15,7 @@ export const actifFilter = (lastActivity: {
         is: {
           OR: [
             { derniereCreationActivite: { not: null } },
-            { mediateursCoordonnes: { some: {} } },
+            { mediateursCoordonnes: { some: { suppression: null } } },
           ],
         },
       },
@@ -31,7 +31,7 @@ export const actifFilter = (lastActivity: {
         is: {
           OR: [
             { derniereCreationActivite: { not: null } },
-            { mediateursCoordonnes: { some: {} } },
+            { mediateursCoordonnes: { some: { suppression: null } } },
           ],
         },
       },

--- a/apps/web/src/features/utilisateurs/use-cases/filter/db/nouveau-filter.ts
+++ b/apps/web/src/features/utilisateurs/use-cases/filter/db/nouveau-filter.ts
@@ -8,7 +8,7 @@ const noActivityFilter: Prisma.UserWhereInput[] = [
     coordinateur: {
       is: {
         derniereCreationActivite: null,
-        mediateursCoordonnes: { none: {} },
+        mediateursCoordonnes: { none: { suppression: null } },
         invitations: noPendingInvitations,
       },
     },
@@ -22,7 +22,7 @@ const noActivityFilter: Prisma.UserWhereInput[] = [
     coordinateur: {
       is: {
         derniereCreationActivite: null,
-        mediateursCoordonnes: { none: {} },
+        mediateursCoordonnes: { none: { suppression: null } },
         invitations: noPendingInvitations,
       },
     },

--- a/apps/web/src/features/utilisateurs/use-cases/filter/filterUtilisateur.spec.ts
+++ b/apps/web/src/features/utilisateurs/use-cases/filter/filterUtilisateur.spec.ts
@@ -32,7 +32,7 @@ describe('filter utilisateur', () => {
             coordinateur: {
               is: {
                 derniereCreationActivite: null,
-                mediateursCoordonnes: { none: {} },
+                mediateursCoordonnes: { none: { suppression: null } },
                 invitations: { none: { acceptee: null, refusee: null } },
               },
             },
@@ -46,7 +46,7 @@ describe('filter utilisateur', () => {
             coordinateur: {
               is: {
                 derniereCreationActivite: null,
-                mediateursCoordonnes: { none: {} },
+                mediateursCoordonnes: { none: { suppression: null } },
                 invitations: { none: { acceptee: null, refusee: null } },
               },
             },

--- a/apps/web/src/features/utilisateurs/use-cases/signup-reminders/signupReminders.ts
+++ b/apps/web/src/features/utilisateurs/use-cases/signup-reminders/signupReminders.ts
@@ -36,7 +36,7 @@ const deleteAndNotify = async (now: Date) => {
       ...inscriptionFilter({ lt: daysAgo(now, 105) }, ['warning_j90_sent']),
       AND: [
         { NOT: { mediateur: { activites: { some: {} } } } },
-        { NOT: { coordinateur: { mediateursCoordonnes: { some: {} } } } },
+        { NOT: { coordinateur: { mediateursCoordonnes: { some: { suppression: null } } } } },
       ],
     },
   })

--- a/apps/web/src/features/utilisateurs/use-cases/signup-reminders/signupReminders.ts
+++ b/apps/web/src/features/utilisateurs/use-cases/signup-reminders/signupReminders.ts
@@ -36,7 +36,13 @@ const deleteAndNotify = async (now: Date) => {
       ...inscriptionFilter({ lt: daysAgo(now, 105) }, ['warning_j90_sent']),
       AND: [
         { NOT: { mediateur: { activites: { some: {} } } } },
-        { NOT: { coordinateur: { mediateursCoordonnes: { some: { suppression: null } } } } },
+        {
+          NOT: {
+            coordinateur: {
+              mediateursCoordonnes: { some: { suppression: null } },
+            },
+          },
+        },
       ],
     },
   })

--- a/apps/web/src/mediateurs/removeMediateurFromTeamOf.ts
+++ b/apps/web/src/mediateurs/removeMediateurFromTeamOf.ts
@@ -3,18 +3,8 @@ import { prismaClient } from '../prismaClient'
 export const removeMediateurFromTeamOf =
   ({ id: coordinateurId }: { id: string }) =>
   async (mediateurId: string) => {
-    const mediateurCoordonne = await prismaClient.mediateurCoordonne.findFirst({
-      where: { mediateurId, coordinateurId },
-    })
-
-    if (mediateurCoordonne == null) {
-      return
-    }
-
-    await prismaClient.mediateurCoordonne.update({
-      where: { id: mediateurCoordonne.id },
-      data: {
-        suppression: new Date(),
-      },
+    await prismaClient.mediateurCoordonne.updateMany({
+      where: { mediateurId, coordinateurId, suppression: null },
+      data: { suppression: new Date() },
     })
   }


### PR DESCRIPTION
The remove team member action could target an already soft-deleted record instead of the active one, causing the UI to spin indefinitely. Replaced findFirst + update with updateMany filtered by suppression: null. Also added missing suppression: null filters in 4 other queries.