### PR TITLE
fix: exclure les utilisateurs supprimés de l'export cartographie

### DIFF
--- a/apps/web/src/app/api/v1/lieux-activite/route.ts
+++ b/apps/web/src/app/api/v1/lieux-activite/route.ts
@@ -323,6 +323,7 @@ export const GET = createApiV1Route
       WHERE structures.suppression IS NULL
         AND mediateurs_en_activite.suppression IS NULL AND mediateurs_en_activite.fin_activite IS NULL
         AND structures.visible_pour_cartographie_nationale IS true
+        AND users.deleted IS NULL
       GROUP BY structures.id
     )
     SELECT *


### PR DESCRIPTION
Les médiateurs ayant supprimé leur compte restaient visibles sur la cartographie nationale car la requête de l'API /v1/lieux-activite ne filtrait pas sur users.deleted.