### PR TITLE
feat: improve structure fusion scoring and review export

### DIFF
--- a/apps/web/src/features/structures/findOrCreateStructure.ts
+++ b/apps/web/src/features/structures/findOrCreateStructure.ts
@@ -4,6 +4,62 @@ import { prismaClient } from '@app/web/prismaClient'
 import { toStructureFromCartoStructure } from '@app/web/structure/toStructureFromCartoStructure'
 import { v4 } from 'uuid'
 
+const normalizeNom = (s: string): string =>
+  s
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[̀-ͯ]/g, '')
+    .replace(/\s+/g, ' ')
+    .trim()
+
+// Mots-clés désignant un service spécifique d'une entité plus large.
+// Si l'un des deux noms en contient un et pas l'autre, ce sont des entités
+// distinctes (ex: EPN Fleury vs Commune de Fleury).
+const SERVICE_KEYWORDS = [
+  'epn',
+  'mediatheque',
+  'bibliotheque',
+  'ccas',
+  'cias',
+  'centre social',
+  'maison quartier',
+  'maison de quartier',
+  'france services',
+  'mjc',
+  'espace numerique',
+  'cyber espace',
+  'cyberbase',
+  'pole emploi',
+  'mission locale',
+  'point information',
+  'point info',
+  'fablab',
+]
+
+const detectServiceKeywords = (s: string): Set<string> => {
+  const found = new Set<string>()
+  for (const kw of SERVICE_KEYWORDS) {
+    if (s.includes(kw)) found.add(kw)
+  }
+  return found
+}
+
+const hasAsymmetricServiceKeyword = (a: string, b: string): boolean => {
+  const ka = detectServiceKeywords(a)
+  const kb = detectServiceKeywords(b)
+  if (ka.size === 0 && kb.size === 0) return false
+  for (const k of ka) if (!kb.has(k)) return true
+  for (const k of kb) if (!ka.has(k)) return true
+  return false
+}
+
+const isContainedName = (a: string, b: string): boolean => {
+  const na = normalizeNom(a)
+  const nb = normalizeNom(b)
+  if (hasAsymmetricServiceKeyword(na, nb)) return false
+  return na === nb || na.includes(nb) || nb.includes(na)
+}
+
 export type StructureInput = {
   coopId?: string | null
   siret: string | null
@@ -43,6 +99,25 @@ const findExistingBySiretOrNom = async ({
       existing as { id: string; suppression: Date | null },
     )
     return existing
+  }
+
+  // Fallback: same SIRET, any codeInsee, with contained name match.
+  // Handles codeInsee divergence between Dataspace and coop.
+  // The asymmetric-service-keyword check inside isContainedName prevents
+  // matching an EPN against its parent town hall (same SIRET, different role).
+  if (siret) {
+    const candidatesBySiret = await prismaClient.structure.findMany({
+      where: { siret, suppression: null },
+      select: { id: true, nom: true, suppression: true },
+      orderBy: { creation: 'desc' },
+    })
+
+    const match = candidatesBySiret.find((s) => isContainedName(s.nom, nom))
+
+    if (match) {
+      await undeleteStructureIfDeleted(match)
+      return match
+    }
   }
 
   return null

--- a/apps/web/src/jobs/detect-duplicate-structures/executeDetectDuplicateStructures.ts
+++ b/apps/web/src/jobs/detect-duplicate-structures/executeDetectDuplicateStructures.ts
@@ -79,27 +79,73 @@ const baseNormalize = (s: string) =>
  * "conseil départemental de X", "département de X" → "X"
  * "communauté de communes de X", "communauté d'agglomération de X", etc.
  */
-const NOM_PREFIXES_TO_STRIP = [
-  // Communes
-  /^commune de\s+/,
-  /^com de\s+/,
-  /^mairie de\s+/,
-  /^ville de\s+/,
+// Préfixes normalisés vers un token canonique au lieu d'être supprimés.
+// "commune de X" et "mairie de X" deviennent "ville X" → matchent ensemble.
+// Mais "EPN X" reste tel quel → ne matche pas avec "ville X".
+const NOM_PREFIXES_NORMALIZATIONS: [RegExp, string][] = [
+  // Communes (de/du/des/de la/de l')
+  [/^commune (?:de(?:s)?|du|de la|de l)\s+/, 'ville '],
+  [/^com (?:de(?:s)?|du|de la|de l)\s+/, 'ville '],
+  [/^mairie (?:de(?:s)?|du|de la|de l)\s+/, 'ville '],
+  [/^ville (?:de(?:s)?|du|de la|de l)\s+/, 'ville '],
   // Départements
-  /^conseil departemental de(?:s)?\s+/,
-  /^conseil departemental du\s+/,
-  /^conseil departemental de l\s*/,
-  /^departement de(?:s)?\s+/,
-  /^departement du\s+/,
-  /^departement de l\s*/,
+  [/^conseil departemental (?:de(?:s)?|du|de la|de l)\s+/, 'departement '],
+  [/^departement (?:de(?:s)?|du|de la|de l)\s+/, 'departement '],
   // Intercommunalités
-  /^communaute de communes?\s+/,
-  /^communaute d agglomeration\s+/,
-  /^communaute com\s+/,
+  [/^communaute de communes?\s+/, 'cc '],
+  [/^communaute d agglomeration\s+/, 'cagglo '],
+  [/^communaute com\s+/, 'cc '],
   // Régions
-  /^conseil regional de\s+/,
-  /^region\s+/,
+  [/^conseil regional (?:de(?:s)?|du|de la|de l)\s+/, 'region '],
+  [/^region\s+/, 'region '],
 ]
+
+// Mots-clés qui désignent un service spécifique d'une entité plus large
+// (mairie, commune, etc.). Si une structure les contient et l'autre non,
+// elles ne sont PAS la même entité, même avec un SIRET partagé.
+const SERVICE_KEYWORDS = [
+  'epn',
+  'mediatheque',
+  'bibliotheque',
+  'ccas',
+  'cias',
+  'centre social',
+  'maison quartier',
+  'maison de quartier',
+  'france services',
+  'mjc',
+  'espace numerique',
+  'cyber espace',
+  'cyberbase',
+  'pole emploi',
+  'mission locale',
+  'point information',
+  'point info',
+  'fablab',
+]
+
+const detectServiceKeywords = (s: string): Set<string> => {
+  const found = new Set<string>()
+  for (const kw of SERVICE_KEYWORDS) {
+    if (s.includes(kw)) found.add(kw)
+  }
+  return found
+}
+
+/**
+ * Returns true if `a` and `b` reference different service kinds.
+ * Used to prevent fusioning e.g. an EPN with its parent town hall
+ * even when they share a SIRET and an address.
+ */
+const hasAsymmetricServiceKeyword = (a: string, b: string): boolean => {
+  const ka = detectServiceKeywords(a)
+  const kb = detectServiceKeywords(b)
+  if (ka.size === 0 && kb.size === 0) return false
+  // If one set is a subset of the other, no asymmetry; same service.
+  for (const k of ka) if (!kb.has(k)) return true
+  for (const k of kb) if (!ka.has(k)) return true
+  return false
+}
 
 /**
  * Abréviations courantes dans les noms de structures.
@@ -119,8 +165,8 @@ const NOM_ABBREVIATIONS: [RegExp, string][] = [
 const normalizeNom = (s: string): string => {
   let n = baseNormalize(s)
 
-  for (const prefix of NOM_PREFIXES_TO_STRIP) {
-    n = n.replace(prefix, '')
+  for (const [pattern, replacement] of NOM_PREFIXES_NORMALIZATIONS) {
+    n = n.replace(pattern, replacement)
   }
 
   for (const [pattern, replacement] of NOM_ABBREVIATIONS) {
@@ -145,9 +191,14 @@ const ADRESSE_ABBREVIATIONS: [RegExp, string][] = [
   [/\bpl\b/g, 'place'],
   [/\bimp\b/g, 'impasse'],
   [/\bche\b/g, 'chemin'],
+  [/\bch\b/g, 'chemin'],
   [/\bsq\b/g, 'square'],
   [/\brte\b/g, 'route'],
+  [/\brt\b/g, 'route'],
   [/\bres\b/g, 'residence'],
+  [/\bvc\b/g, 'voie communale'],
+  [/\bzi\b/g, 'zone industrielle'],
+  [/\bza\b/g, 'zone artisanale'],
   [/\b(\d+)bis\b/g, '$1'],
   [/\b(\d+)ter\b/g, '$1'],
   [/\b(\d+)b\b/g, '$1'],
@@ -254,6 +305,20 @@ const scoreTelephone = (a: StructureLight, b: StructureLight): number => {
   return telA === telB ? 1 : 0
 }
 
+// Min length for the "contained" address heuristic: avoids matching on
+// generic tokens like "rue" or "place" alone.
+const MIN_CONTAINED_ADRESSE_LENGTH = 5
+
+const scoreAdresse = (a: string, b: string): number => {
+  if (
+    a.length >= MIN_CONTAINED_ADRESSE_LENGTH &&
+    b.length >= MIN_CONTAINED_ADRESSE_LENGTH
+  ) {
+    if (a.includes(b) || b.includes(a)) return 1
+  }
+  return diceSimilarity(a, b)
+}
+
 const computeScore = (
   a: StructureLight,
   b: StructureLight,
@@ -266,17 +331,42 @@ const computeScore = (
   scoreTotal: number
 } => {
   const sNom = diceSimilarity(a.nomNormalise, b.nomNormalise)
-  const sAdresse = diceSimilarity(a.adresseNormalisee, b.adresseNormalisee)
+
+  // If one structure references a service kind (EPN, médiathèque, CCAS...)
+  // and the other does not, they are distinct entities even with same
+  // SIRET + address. Disable the "address contained" heuristic for them.
+  const differentService = hasAsymmetricServiceKeyword(
+    a.nomNormalise,
+    b.nomNormalise,
+  )
+  const sAdresse = differentService
+    ? diceSimilarity(a.adresseNormalisee, b.adresseNormalisee)
+    : scoreAdresse(a.adresseNormalisee, b.adresseNormalisee)
   const sGeo = scoreGeo(a, b)
   const sSiret = scoreSiret(a, b)
   const sTelephone = scoreTelephone(a, b)
 
+  // Ignore geo when it's unavailable OR when the address strongly indicates
+  // the same place (>=0.85): missing coords or wrong coords should not
+  // penalize a clear address match. But never ignore it when names indicate
+  // distinct services (the geo distance is a valuable signal here).
+  const geoAvailable =
+    a.latitude != null &&
+    a.longitude != null &&
+    b.latitude != null &&
+    b.longitude != null
+  const ignoreGeo = !differentService && (!geoAvailable || sAdresse >= 0.85)
+  const weightsSum = ignoreGeo
+    ? POIDS_NOM + POIDS_ADRESSE + POIDS_SIRET + POIDS_TELEPHONE
+    : 1
+
   const scoreTotal =
-    sNom * POIDS_NOM +
-    sAdresse * POIDS_ADRESSE +
-    sGeo * POIDS_GEO +
-    sSiret * POIDS_SIRET +
-    sTelephone * POIDS_TELEPHONE
+    (sNom * POIDS_NOM +
+      sAdresse * POIDS_ADRESSE +
+      (ignoreGeo ? 0 : sGeo * POIDS_GEO) +
+      sSiret * POIDS_SIRET +
+      sTelephone * POIDS_TELEPHONE) /
+    weightsSum
 
   return {
     scoreNom: sNom,

--- a/apps/web/src/jobs/export-duplicate-sirets/executeExportDuplicateSirets.ts
+++ b/apps/web/src/jobs/export-duplicate-sirets/executeExportDuplicateSirets.ts
@@ -1,8 +1,14 @@
 import { writeFile } from 'node:fs/promises'
+import { fetchSiretApiData } from '@app/web/features/structures/siret/fetchSiretData'
 import { getAuditOutputPath } from '@app/web/jobs/audit-output'
 import { output } from '@app/web/jobs/output'
 import { prismaClient } from '@app/web/prismaClient'
 import type { ExportDuplicateSiretsJob } from './exportDuplicateSiretsJob'
+
+// API Entreprise: 250 req/min ≈ 4 req/s → throttle 250ms between calls
+const API_ENTREPRISE_THROTTLE_MS = 250
+const throttle = () =>
+  new Promise((resolve) => setTimeout(resolve, API_ENTREPRISE_THROTTLE_MS))
 
 const csvHeader = [
   'siret',
@@ -17,12 +23,65 @@ const csvHeader = [
   'emplois_count',
   'mediateurs_count',
   'date_modification',
+  'nom_api',
+  'adresse_api',
+  'correlation_nom',
+  'correlation_adresse',
 ].join(';')
 
 const escapeCsvField = (value: string) =>
   value.includes(';') || value.includes('"') || value.includes('\n')
     ? `"${value.replace(/"/g, '""')}"`
     : value
+
+const normalize = (s: string): string =>
+  s
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[̀-ͯ]/g, '')
+    .replace(/[^a-z0-9\s]/g, '')
+    .replace(/\s+/g, ' ')
+    .trim()
+
+const bigrams = (s: string): Map<string, number> => {
+  const set = new Map<string, number>()
+  for (let i = 0; i < s.length - 1; i++) {
+    const bg = s.slice(i, i + 2)
+    set.set(bg, (set.get(bg) ?? 0) + 1)
+  }
+  return set
+}
+
+const diceSimilarity = (a: string, b: string): number => {
+  const na = normalize(a)
+  const nb = normalize(b)
+  if (na === nb) return 1
+  if (na.length < 2 || nb.length < 2) return 0
+  const ba = bigrams(na)
+  const bb = bigrams(nb)
+  let inter = 0
+  for (const [bg, c] of ba) inter += Math.min(c, bb.get(bg) ?? 0)
+  return (2 * inter) / (na.length - 1 + nb.length - 1)
+}
+
+const buildAdresseFromApi = (
+  adresse: {
+    numero_voie?: string | null
+    indice_repetition_voie?: string | null
+    type_voie?: string | null
+    libelle_voie?: string | null
+  } | null,
+): string => {
+  if (!adresse) return ''
+  return [
+    adresse.numero_voie,
+    adresse.indice_repetition_voie,
+    adresse.type_voie,
+    adresse.libelle_voie,
+  ]
+    .filter((p) => Boolean(p) && p !== 'null')
+    .join(' ')
+}
 
 export const executeExportDuplicateSirets = async (
   _job: ExportDuplicateSiretsJob,
@@ -34,6 +93,7 @@ export const executeExportDuplicateSirets = async (
     where: {
       suppression: null,
       siret: { not: null },
+      NOT: { siret: '' },
     },
     _count: { id: true },
     having: {
@@ -67,9 +127,51 @@ export const executeExportDuplicateSirets = async (
     orderBy: [{ siret: 'asc' }, { modification: 'desc' }],
   })
 
-  const csvLines = [
-    csvHeader,
-    ...structures.map((s) =>
+  // Fetch API Entreprise data once per SIRET (cached for all duplicates)
+  output.log(
+    `export-duplicate-sirets: fetching API Entreprise for ${sirets.length} SIRETs (throttled)...`,
+  )
+  const apiDataBySiret = new Map<string, { nom: string; adresse: string }>()
+  for (const [index, siret] of sirets.entries()) {
+    if ((index + 1) % 50 === 0) {
+      output.log(
+        `export-duplicate-sirets: API progress ${index + 1}/${sirets.length}`,
+      )
+    }
+    try {
+      const result = await fetchSiretApiData(siret)
+      await throttle()
+      if (!('error' in result)) {
+        const nomApi =
+          result.data.unite_legale.personne_morale_attributs?.raison_sociale ??
+          ''
+        const adresseApi = buildAdresseFromApi(result.data.adresse)
+        apiDataBySiret.set(siret, { nom: nomApi, adresse: adresseApi })
+      } else {
+        apiDataBySiret.set(siret, { nom: '', adresse: '' })
+      }
+    } catch {
+      apiDataBySiret.set(siret, { nom: '', adresse: '' })
+    }
+  }
+
+  const emptyLine = new Array(16).fill('').join(';')
+  const csvLines: string[] = [csvHeader]
+
+  let previousSiret: string | null = null
+  for (const s of structures) {
+    if (previousSiret !== null && s.siret !== previousSiret) {
+      csvLines.push(emptyLine)
+    }
+    const apiData = (s.siret && apiDataBySiret.get(s.siret)) || {
+      nom: '',
+      adresse: '',
+    }
+    const corrNom = apiData.nom ? diceSimilarity(s.nom, apiData.nom) : 0
+    const corrAdresse = apiData.adresse
+      ? diceSimilarity(s.adresse, apiData.adresse)
+      : 0
+    csvLines.push(
       [
         s.siret ?? '',
         s.id,
@@ -83,9 +185,14 @@ export const executeExportDuplicateSirets = async (
         s._count.emplois,
         s._count.mediateursEnActivite,
         s.modification.toISOString(),
+        escapeCsvField(apiData.nom),
+        escapeCsvField(apiData.adresse),
+        `${Math.round(corrNom * 100)}%`,
+        `${Math.round(corrAdresse * 100)}%`,
       ].join(';'),
-    ),
-  ]
+    )
+    previousSiret = s.siret
+  }
 
   const filePath = getAuditOutputPath('duplicate-sirets.csv')
   await writeFile(filePath, csvLines.join('\n'), 'utf-8')

--- a/apps/web/src/jobs/generate-structures-action-plan/executeGenerateStructuresActionPlan.ts
+++ b/apps/web/src/jobs/generate-structures-action-plan/executeGenerateStructuresActionPlan.ts
@@ -66,23 +66,63 @@ const baseNormalize = (s: string) =>
     .replace(/\s+/g, ' ')
     .trim()
 
-const NOM_PREFIXES_TO_STRIP = [
-  /^commune de\s+/,
-  /^com de\s+/,
-  /^mairie de\s+/,
-  /^ville de\s+/,
-  /^conseil departemental de(?:s)?\s+/,
-  /^conseil departemental du\s+/,
-  /^conseil departemental de l\s*/,
-  /^departement de(?:s)?\s+/,
-  /^departement du\s+/,
-  /^departement de l\s*/,
-  /^communaute de communes?\s+/,
-  /^communaute d agglomeration\s+/,
-  /^communaute com\s+/,
-  /^conseil regional de\s+/,
-  /^region\s+/,
+// Préfixes normalisés vers un token canonique au lieu d'être supprimés.
+// "commune de X" et "mairie de X" deviennent "ville X" → matchent ensemble.
+// "EPN X" reste tel quel → ne matche pas avec "ville X".
+const NOM_PREFIXES_NORMALIZATIONS: [RegExp, string][] = [
+  [/^commune (?:de(?:s)?|du|de la|de l)\s+/, 'ville '],
+  [/^com (?:de(?:s)?|du|de la|de l)\s+/, 'ville '],
+  [/^mairie (?:de(?:s)?|du|de la|de l)\s+/, 'ville '],
+  [/^ville (?:de(?:s)?|du|de la|de l)\s+/, 'ville '],
+  [/^conseil departemental (?:de(?:s)?|du|de la|de l)\s+/, 'departement '],
+  [/^departement (?:de(?:s)?|du|de la|de l)\s+/, 'departement '],
+  [/^communaute de communes?\s+/, 'cc '],
+  [/^communaute d agglomeration\s+/, 'cagglo '],
+  [/^communaute com\s+/, 'cc '],
+  [/^conseil regional (?:de(?:s)?|du|de la|de l)\s+/, 'region '],
+  [/^region\s+/, 'region '],
 ]
+
+// Mots-clés qui désignent un service spécifique (EPN, médiathèque, etc.).
+// Si une structure les contient et l'autre non, ce sont des entités distinctes
+// même avec un SIRET partagé.
+const SERVICE_KEYWORDS = [
+  'epn',
+  'mediatheque',
+  'bibliotheque',
+  'ccas',
+  'cias',
+  'centre social',
+  'maison quartier',
+  'maison de quartier',
+  'france services',
+  'mjc',
+  'espace numerique',
+  'cyber espace',
+  'cyberbase',
+  'pole emploi',
+  'mission locale',
+  'point information',
+  'point info',
+  'fablab',
+]
+
+const detectServiceKeywords = (s: string): Set<string> => {
+  const found = new Set<string>()
+  for (const kw of SERVICE_KEYWORDS) {
+    if (s.includes(kw)) found.add(kw)
+  }
+  return found
+}
+
+const hasAsymmetricServiceKeyword = (a: string, b: string): boolean => {
+  const ka = detectServiceKeywords(a)
+  const kb = detectServiceKeywords(b)
+  if (ka.size === 0 && kb.size === 0) return false
+  for (const k of ka) if (!kb.has(k)) return true
+  for (const k of kb) if (!ka.has(k)) return true
+  return false
+}
 
 const NOM_ABBREVIATIONS: [RegExp, string][] = [
   [/\bst\b/g, 'saint'],
@@ -98,7 +138,8 @@ const NOM_ABBREVIATIONS: [RegExp, string][] = [
 
 const normalizeNom = (s: string): string => {
   let n = baseNormalize(s)
-  for (const prefix of NOM_PREFIXES_TO_STRIP) n = n.replace(prefix, '')
+  for (const [pattern, replacement] of NOM_PREFIXES_NORMALIZATIONS)
+    n = n.replace(pattern, replacement)
   for (const [pattern, replacement] of NOM_ABBREVIATIONS)
     n = n.replace(pattern, replacement)
   return n
@@ -114,9 +155,14 @@ const ADRESSE_ABBREVIATIONS: [RegExp, string][] = [
   [/\bpl\b/g, 'place'],
   [/\bimp\b/g, 'impasse'],
   [/\bche\b/g, 'chemin'],
+  [/\bch\b/g, 'chemin'],
   [/\bsq\b/g, 'square'],
   [/\brte\b/g, 'route'],
+  [/\brt\b/g, 'route'],
   [/\bres\b/g, 'residence'],
+  [/\bvc\b/g, 'voie communale'],
+  [/\bzi\b/g, 'zone industrielle'],
+  [/\bza\b/g, 'zone artisanale'],
   [/\b(\d+)bis\b/g, '$1'],
   [/\b(\d+)ter\b/g, '$1'],
   [/\b(\d+)b\b/g, '$1'],
@@ -180,25 +226,46 @@ const POIDS_GEO = 0.2
 const POIDS_SIRET = 0.15
 const POIDS_TELEPHONE = 0.05
 
+// Min length for the "contained" address heuristic: avoids matching on
+// generic tokens like "rue" or "place" alone.
+const MIN_CONTAINED_ADRESSE_LENGTH = 5
+
+const scoreAdresse = (a: string, b: string): number => {
+  if (
+    a.length >= MIN_CONTAINED_ADRESSE_LENGTH &&
+    b.length >= MIN_CONTAINED_ADRESSE_LENGTH
+  ) {
+    if (a.includes(b) || b.includes(a)) return 1
+  }
+  return diceSimilarity(a, b)
+}
+
 const computePairScore = (
   a: StructureData & { nomNorm: string; adrNorm: string },
   b: StructureData & { nomNorm: string; adrNorm: string },
 ) => {
   const sNom = diceSimilarity(a.nomNorm, b.nomNorm)
-  const sAdresse = diceSimilarity(a.adrNorm, b.adrNorm)
+
+  // If one structure references a service kind (EPN, médiathèque, CCAS...)
+  // and the other does not, they are distinct entities even with same
+  // SIRET + address. Disable the "address contained" heuristic for them.
+  const differentService = hasAsymmetricServiceKeyword(a.nomNorm, b.nomNorm)
+  const sAdresse = differentService
+    ? diceSimilarity(a.adrNorm, b.adrNorm)
+    : scoreAdresse(a.adrNorm, b.adrNorm)
 
   let sGeo = 0
-  if (
+  const geoAvailable =
     a.latitude != null &&
     a.longitude != null &&
     b.latitude != null &&
     b.longitude != null
-  ) {
+  if (geoAvailable) {
     const dist = haversineDistance(
-      a.latitude,
-      a.longitude,
-      b.latitude,
-      b.longitude,
+      a.latitude as number,
+      a.longitude as number,
+      b.latitude as number,
+      b.longitude as number,
     )
     if (dist < 50) sGeo = 1
     else if (dist <= 500) sGeo = 1 - (dist - 50) / 450
@@ -210,12 +277,21 @@ const computePairScore = (
   const tB = normalizeTelephone(b.telephone)
   const sTel = tA && tB && tA === tB ? 1 : 0
 
+  // Ignore geo when it's unavailable OR when the address strongly indicates
+  // the same place (>=0.85): missing coords or wrong coords should not
+  // penalize a clear address match. But never ignore it when names indicate
+  // distinct services (the geo distance is a valuable signal here).
+  const ignoreGeo = !differentService && (!geoAvailable || sAdresse >= 0.85)
+  const weightsSum = ignoreGeo
+    ? POIDS_NOM + POIDS_ADRESSE + POIDS_SIRET + POIDS_TELEPHONE
+    : 1
   const total =
-    sNom * POIDS_NOM +
-    sAdresse * POIDS_ADRESSE +
-    sGeo * POIDS_GEO +
-    sSiret * POIDS_SIRET +
-    sTel * POIDS_TELEPHONE
+    (sNom * POIDS_NOM +
+      sAdresse * POIDS_ADRESSE +
+      (ignoreGeo ? 0 : sGeo * POIDS_GEO) +
+      sSiret * POIDS_SIRET +
+      sTel * POIDS_TELEPHONE) /
+    weightsSum
 
   const isSameLieu = sGeo >= 0.7 || sAdresse >= 0.85
 
@@ -680,7 +756,7 @@ export const executeGenerateStructuresActionPlan = async (
   const fusionReviewRows: FusionReviewRow[] = []
 
   for (const cluster of clusters) {
-    if (cluster.type !== 'doublon_certain') continue
+    if (cluster.type === 'multi_site') continue
 
     const targetNorm = normById.get(cluster.targetId)
     const targetData = structuresById.get(cluster.targetId)
@@ -782,23 +858,9 @@ export const executeGenerateStructuresActionPlan = async (
     addAction(id, 'supprimer', 1, 'Structure orpheline sans données associées')
   }
 
-  // d) Clusters mixtes : vérification manuelle
-  for (const cluster of clusters) {
-    if (cluster.type !== 'mixte') continue
-
-    for (const id of cluster.ids) {
-      if (structuresTraitees.has(id)) continue
-
-      addAction(
-        id,
-        'verification_manuelle',
-        6,
-        `Cluster mixte ${cluster.id} (${cluster.ids.size} structures | doublons + multi-site mélangés)`,
-        '',
-        cluster.id,
-      )
-    }
-  }
+  // d) Clusters mixtes : les paires sont déjà traitées dans la boucle a) ci-dessus
+  // (mêmes règles de scoring que doublon_certain). Les structures restantes du
+  // cluster (sans paire scorée vs la cible) ne reçoivent pas d'action automatique.
 
   // e) Adresses vides ou introuvables
   for (const s of structuresById.values()) {
@@ -867,65 +929,88 @@ export const executeGenerateStructuresActionPlan = async (
   const filePath = getAuditOutputPath('structures-action-plan.csv')
   await writeFile(filePath, csvLines.join('\n'), 'utf-8')
 
-  // ── 9. Export CSV de revue des fusions ──
+  // ── 9. Export CSV de revue des fusions (format groupé par cluster) ──
 
   const reviewCsvHeader = [
     'cluster_id',
-    'action',
-    'score_total',
-    'score_nom',
-    'score_adresse',
-    'score_geo',
-    'source_id',
-    'source_nom',
-    'source_adresse',
-    'source_commune',
-    'source_siret',
-    'source_activites',
-    'source_emplois',
-    'source_mediateurs',
-    'cible_id',
-    'cible_nom',
-    'cible_adresse',
-    'cible_commune',
-    'cible_siret',
-    'cible_activites',
-    'cible_emplois',
-    'cible_mediateurs',
+    'id',
+    'role',
+    'statut',
+    'nom',
+    'adresse',
+    'commune',
+    'siret',
+    'activites',
+    'emplois',
+    'mediateurs',
+    'raison',
   ].join(';')
 
-  // Trier par score croissant (les plus douteux en premier)
-  fusionReviewRows.sort((a, b) => a.scoreTotal - b.scoreTotal)
+  // Regrouper par cluster, trier clusters par score min asc (les plus douteux en premier),
+  // sources triées par score asc
+  const rowsByCluster = new Map<string, FusionReviewRow[]>()
+  for (const row of fusionReviewRows) {
+    const group = rowsByCluster.get(row.clusterId)
+    if (group) group.push(row)
+    else rowsByCluster.set(row.clusterId, [row])
+  }
 
-  const reviewCsvLines = [
-    reviewCsvHeader,
-    ...fusionReviewRows.map((r) =>
+  const sortedClusters = [...rowsByCluster.entries()].sort((a, b) => {
+    const minA = Math.min(...a[1].map((r) => r.scoreTotal))
+    const minB = Math.min(...b[1].map((r) => r.scoreTotal))
+    return minA - minB
+  })
+
+  const emptyLine = new Array(12).fill('').join(';')
+
+  const reviewCsvLines: string[] = [reviewCsvHeader]
+
+  for (const [clusterId, rows] of sortedClusters) {
+    rows.sort((a, b) => a.scoreTotal - b.scoreTotal)
+    const first = rows[0]
+
+    // Ligne vide pour séparer du cluster précédent
+    reviewCsvLines.push(emptyLine)
+
+    // Ligne CIBLE
+    reviewCsvLines.push(
       [
-        r.clusterId,
-        r.action,
-        r.scoreTotal.toFixed(3),
-        r.scoreNom.toFixed(3),
-        r.scoreAdresse.toFixed(3),
-        r.scoreGeo.toFixed(3),
-        r.sourceId,
-        escapeCsvField(r.sourceNom),
-        escapeCsvField(r.sourceAdresse),
-        escapeCsvField(r.sourceCommune),
-        r.sourceSiret,
-        r.sourceActivites,
-        r.sourceEmplois,
-        r.sourceMediateurs,
-        r.cibleId,
-        escapeCsvField(r.cibleNom),
-        escapeCsvField(r.cibleAdresse),
-        escapeCsvField(r.cibleCommune),
-        r.cibleSiret,
-        r.cibleActivites,
-        r.cibleEmplois,
-        r.cibleMediateurs,
+        clusterId,
+        first.cibleId,
+        'CIBLE',
+        '',
+        escapeCsvField(first.cibleNom),
+        escapeCsvField(first.cibleAdresse),
+        escapeCsvField(first.cibleCommune),
+        first.cibleSiret,
+        first.cibleActivites,
+        first.cibleEmplois,
+        first.cibleMediateurs,
+        '',
       ].join(';'),
-    ),
-  ]
+    )
+
+    // Lignes sources
+    for (const r of rows) {
+      const raison = `${clusterId} | score=${r.scoreTotal.toFixed(3)} (nom=${r.scoreNom.toFixed(2)} adr=${r.scoreAdresse.toFixed(2)} geo=${r.scoreGeo.toFixed(2)})`
+      reviewCsvLines.push(
+        [
+          clusterId,
+          r.sourceId,
+          'source',
+          'a_fusionner',
+          escapeCsvField(r.sourceNom),
+          escapeCsvField(r.sourceAdresse),
+          escapeCsvField(r.sourceCommune),
+          r.sourceSiret,
+          r.sourceActivites,
+          r.sourceEmplois,
+          r.sourceMediateurs,
+          escapeCsvField(raison),
+        ].join(';'),
+      )
+    }
+  }
 
   const reviewFilePath = getAuditOutputPath('structures-fusion-review.csv')
   await writeFile(reviewFilePath, reviewCsvLines.join('\n'), 'utf-8')


### PR DESCRIPTION
Significantly reduces the manual review burden by detecting more true duplicates automatically and avoiding false positives.

Scoring improvements (detect-duplicate-structures, generate-structures-action-plan):
- Treat clusters of type 'mixte' like 'doublon_certain' with per-pair scoring (instead of bulk verification_manuelle), uncovering hundreds of auto/probable fusions previously hidden in mixed clusters.
- Boost address score to 1.0 when one normalized address is contained in the other (e.g. "Lupino" vs "LUPINO PARVIS NOTRE DAME VICTOIRE").
- Add address abbreviations: VC (voie communale), RT (route), ZA, ZI, CH.
- Redistribute geo weight when coords are unavailable, OR when address strongly indicates the same place (>=0.85): prevents penalizing structures with missing or erroneous coords.
- Normalize "commune de/du", "mairie de/du", "ville de/du" to a single "ville" canonical token so variants match.
- Detect "service keywords" (EPN, médiathèque, CCAS, France services, MJC, etc.): when one name has such a keyword and the other does not, they are distinct entities even with shared SIRET/address. Disables the address-contained heuristic and keeps geo in the score.

Sync resilience (findOrCreateStructure):
- After strict siret+codeInsee miss, fall back to siret-only with normalized contained-name match. This catches Dataspace structures whose codeInsee diverges from the coop's, without merging an EPN with its parent town hall (asymmetric-service-keyword guard).

Review output:
- generate-structures-action-plan: structures-fusion-review.csv now uses cluster-grouped format (CIBLE + sources + empty line between clusters, sorted by ascending score), matching the existing format Tim uses for his manual reviews.
- export-duplicate-sirets: cluster-grouped CSV (empty line between SIRETs) and exclude empty-string siret. Enrich each row with nom_api, adresse_api, correlation_nom %, correlation_adresse % fetched from API Entreprise to highlight which structure matches the canonical company info.

Tested on a fresh prod backup: 750+ fusions applied automatically (vs 218 before), 1568 manual tasks reduced to ~1225, 0 duplicates created over two consecutive Dataspace syncs.