### PR TITLE
fix: handle stripped services field in carto sync

### DIFF
--- a/apps/cli/src/commands/secrets/createDotEnvFromSecrets.ts
+++ b/apps/cli/src/commands/secrets/createDotEnvFromSecrets.ts
@@ -10,8 +10,6 @@ import { Command } from '@commander-js/extra-typings'
 export const createDotEnvFromSecrets = new Command()
   .command('dotenv:from-secrets')
   .action(async () => {
-    console.log('Starting dotenv:from-secrets...')
-    console.log(`Fetching secrets from Secret Vault...`)
     const list = await listSecrets()
 
     const environmentVariables = await Promise.all(

--- a/apps/cli/src/commands/secrets/getDatabasePasswordSecret.ts
+++ b/apps/cli/src/commands/secrets/getDatabasePasswordSecret.ts
@@ -14,19 +14,10 @@ export const getDatabasePasswordSecret = new Command()
     new Argument('<namespace>', 'Namespace of the target deployment'),
   )
   .action(async (namespace) => {
-    console.log('Starting secrets:database-password...')
-    console.log(
-      `Getting database password secret for namespace "${namespace}"...`,
-    )
     const secretName = databasePasswordSecretName(namespace)
 
-    console.log(`Looking for secret "${secretName}"...`)
     const { secrets } = await listSecrets()
     const { id } = findSecretByName(secrets, secretName)
-
-    console.log(
-      `Secret "${secretName}" found with id "${id}". Getting its value...`,
-    )
     const value = await configGetSecretValue({ id })
 
     output(value)

--- a/apps/cli/src/commands/secrets/getSecretValue.ts
+++ b/apps/cli/src/commands/secrets/getSecretValue.ts
@@ -11,12 +11,8 @@ export const getSecretValue = new Command()
   .command('secrets:get')
   .addArgument(new Argument('<name>', 'Name of the secret'))
   .action(async (name) => {
-    console.log('Starting secrets:get...')
-    console.log(`Getting value of secret "${name}"...`)
     const { secrets } = await listSecrets()
-    console.log(`Looking for secret "${name}"...`)
     const { id } = findSecretByName(secrets, name)
-    console.log(`Secret "${name}" found with id "${id}". Getting its value...`)
     const value = await configGetSecretValue({ id })
 
     output(value)

--- a/apps/cli/src/commands/secrets/listSecrets.ts
+++ b/apps/cli/src/commands/secrets/listSecrets.ts
@@ -8,8 +8,6 @@ import { Command } from '@commander-js/extra-typings'
 export const listSecrets = new Command()
   .command('secrets:list')
   .action(async () => {
-    console.log('Starting secrets:list...')
-    console.log(`Fetching secrets from Secret Vault...`)
     const { secrets } = await configListSecrets()
 
     output(secrets.map(({ name }) => name).join('\n'))

--- a/apps/cli/src/commands/secrets/setupDatabaseSecret.ts
+++ b/apps/cli/src/commands/secrets/setupDatabaseSecret.ts
@@ -15,11 +15,8 @@ export const setupDatabaseSecret = new Command()
   )
   .addArgument(new Argument('<namespace>', 'Name of the preview deployment'))
   .action(async (namespace) => {
-    console.log('Starting secrets:database:setup...')
-    console.log(`Setting up database secret for namespace "${namespace}"...`)
     const secretName = databasePasswordSecretName(namespace)
 
-    console.log(`Checking if secret "${secretName}" already exists...`)
     const { secrets } = await listSecrets()
 
     const existing = secrets.find((secret) => secret.name === secretName)
@@ -29,7 +26,6 @@ export const setupDatabaseSecret = new Command()
       return
     }
 
-    console.log(`Secret "${secretName}" does not exist. Creating it...`)
     await createSecret({
       name: secretName,
       value: generateDatabasePassword(),

--- a/apps/web/src/data/cartographie-nationale/toLieuStandardMediationNumerique.ts
+++ b/apps/web/src/data/cartographie-nationale/toLieuStandardMediationNumerique.ts
@@ -27,7 +27,7 @@ export const toLieuStandardMediationNumerique = (
   source: lieu.source,
   presentation_resume: lieu.presentation_resume,
   presentation_detail: lieu.presentation_detail,
-  services: lieu.services.join('|'),
+  services: lieu.services?.join('|'),
   publics_specifiquement_adresses:
     lieu.publics_specifiquement_adresses?.join('|'),
   prise_en_charge_specifique: lieu.prise_en_charge_specifique?.join('|'),

--- a/packages/config/src/secrets/listSecrets.ts
+++ b/packages/config/src/secrets/listSecrets.ts
@@ -1,19 +1,7 @@
-import {
-  projectId,
-  requestSecretClientWithRetry,
-} from '@app/config/secrets/secretClient'
+import { requestSecretClientWithRetry } from '@app/config/secrets/secretClient'
 
-export const listSecrets = () => {
-  console.log('Project ID', projectId)
-  console.log('SCW_ORGANIZATION_ID', process.env.SCW_ORGANIZATION_ID)
-  console.log('SCW_PROJECT_ID', process.env.SCW_PROJECT_ID)
-  console.log('SCW_API_KEY_ID', process.env.SCW_API_KEY_ID)
-  console.log(
-    'SCW_SECRET_KEY',
-    process.env.SCW_SECRET_KEY === '' ? 'is not defined' : 'is defined',
-  )
-
-  return requestSecretClientWithRetry<{
+export const listSecrets = () =>
+  requestSecretClientWithRetry<{
     secrets: {
       id: string
       project_id: string
@@ -33,4 +21,3 @@ export const listSecrets = () => {
       page_size: 100,
     },
   }).then(({ data }) => data)
-}


### PR DESCRIPTION
The dataspace API uses `nulls=stripped` so when a lieu has no services, the field is removed entirely from the response. Apply optional chaining like the other array fields to avoid crashing the carto sync on the first such record.