### PR TITLE
fix: prevent dataspace sync from creating duplicate structures

### DIFF
--- a/apps/web/src/features/structures/findOrCreateStructure.ts
+++ b/apps/web/src/features/structures/findOrCreateStructure.ts
@@ -4,13 +4,42 @@ import { prismaClient } from '@app/web/prismaClient'
 import { toStructureFromCartoStructure } from '@app/web/structure/toStructureFromCartoStructure'
 import { v4 } from 'uuid'
 
-const normalizeNom = (s: string): string =>
+// Préfixes administratifs interchangeables, normalisés vers un token canonique.
+// "commune de X", "mairie de X", "ville de X", "hôtel de ville de X" → "ville X"
+// Permet à findOrCreateStructure de matcher "MAIRIE DU PRÊCHEUR" avec
+// "COMMUNE DU PRECHEUR" pour le même SIRET, et ainsi d'éviter les doublons
+// quand le Dataspace renvoie une variante de nom différente de la base.
+const NOM_PREFIXES_NORMALIZATIONS: [RegExp, string][] = [
+  [/^commune (?:de(?:s)?|du|de la|de l)\s+/, 'ville '],
+  [/^com (?:de(?:s)?|du|de la|de l)\s+/, 'ville '],
+  [/^mairie (?:de(?:s)?|du|de la|de l)\s+/, 'ville '],
+  [/^ville (?:de(?:s)?|du|de la|de l)\s+/, 'ville '],
+  [/^hotel de ville (?:de(?:s)?|du|de la|de l)\s+/, 'ville '],
+  [/^conseil departemental (?:de(?:s)?|du|de la|de l)\s+/, 'departement '],
+  [/^departement (?:de(?:s)?|du|de la|de l)\s+/, 'departement '],
+  [/^communaute de communes?\s+/, 'cc '],
+  [/^communaute d agglomeration\s+/, 'cagglo '],
+  [/^communaute com\s+/, 'cc '],
+  [/^conseil regional (?:de(?:s)?|du|de la|de l)\s+/, 'region '],
+  [/^region\s+/, 'region '],
+]
+
+const baseNormalize = (s: string): string =>
   s
     .toLowerCase()
     .normalize('NFD')
     .replace(/[̀-ͯ]/g, '')
+    .replace(/[^a-z0-9\s]/g, ' ')
     .replace(/\s+/g, ' ')
     .trim()
+
+const normalizeNom = (s: string): string => {
+  let n = baseNormalize(s)
+  for (const [pattern, replacement] of NOM_PREFIXES_NORMALIZATIONS) {
+    n = n.replace(pattern, replacement)
+  }
+  return n.trim()
+}
 
 // Mots-clés désignant un service spécifique d'une entité plus large.
 // Si l'un des deux noms en contient un et pas l'autre, ce sont des entités

--- a/apps/web/src/jobs/apply-fusionner-structures/applyFusionnerStructuresJob.ts
+++ b/apps/web/src/jobs/apply-fusionner-structures/applyFusionnerStructuresJob.ts
@@ -10,6 +10,12 @@ export const ApplyFusionnerStructuresJobValidation = z.object({
       'fusionner_review',
     ]),
     dryRun: z.boolean().optional().default(true),
+    // If a cluster in the action plan contains at least one structure (source
+    // or target) listed here, the entire cluster is skipped. Use to protect
+    // risky fusions (e.g. several active structures with many activities)
+    // until they have been validated manually. Structure UUIDs are stable
+    // across plan regenerations.
+    excludeStructureIds: z.array(z.string().uuid()).optional(),
   }),
 })
 

--- a/apps/web/src/jobs/apply-fusionner-structures/executeApplyFusionnerStructures.ts
+++ b/apps/web/src/jobs/apply-fusionner-structures/executeApplyFusionnerStructures.ts
@@ -44,13 +44,39 @@ export const executeApplyFusionnerStructures = async (
 ) => {
   const { action } = job.payload
   const dryRun = job.payload.dryRun ?? true
+  const excludeStructureIds = new Set(job.payload.excludeStructureIds ?? [])
 
   output.log(
     `apply-fusionner-structures: starting (${action})${dryRun ? ' (DRY RUN)' : ''}...`,
   )
 
   const actionPlan = await readActionPlan()
-  const toMerge = filterActionPlan(actionPlan, action)
+  const allToMerge = filterActionPlan(actionPlan, action)
+
+  // Find every cluster that contains at least one excluded structure
+  // (either as a source or as the merge target).
+  const excludedClusterIds = new Set<string>()
+  if (excludeStructureIds.size > 0) {
+    for (const row of allToMerge) {
+      if (
+        excludeStructureIds.has(row.id) ||
+        (row.cibleFusion && excludeStructureIds.has(row.cibleFusion))
+      ) {
+        excludedClusterIds.add(row.clusterId)
+      }
+    }
+  }
+
+  const toMerge = allToMerge.filter(
+    (row) => !excludedClusterIds.has(row.clusterId),
+  )
+  const excludedCount = allToMerge.length - toMerge.length
+
+  if (excludedClusterIds.size > 0) {
+    output.log(
+      `apply-fusionner-structures: ${excludedCount} structures exclues (${excludedClusterIds.size} clusters: ${[...excludedClusterIds].join(', ')})`,
+    )
+  }
 
   output.log(
     `apply-fusionner-structures: ${toMerge.length} structures à fusionner`,


### PR DESCRIPTION
Two improvements to break the daily-duplicate cycle observed on the Dataspace sync:

1. Normalize administrative prefixes in findOrCreateStructure.

   The Dataspace sometimes returns a name variant that differs only by the administrative prefix ("Mairie Du Prêcheur Le Prêcheur" vs the stored "COMMUNE DU PRECHEUR"). The siret+codeInsee match also fails because the Dataspace ships the head office codeInsee, which differs from the cartographie nationale code stored in DB. The siret-only fallback with contained-name match then misses because the prefixes diverge.

   The new normalizeNom collapses "commune de X", "mairie de X", "ville de X", "hôtel de ville de X" (and the départemental/régional equivalents) to a single canonical "ville X" token, so the fallback correctly groups them. Tested on prod backup: 3 sync cycles in a row, zero duplicate created, real new structures still created normally.

2. Add excludeStructureIds option to apply-fusionner-structures.

   Some clusters (Choisy-le-Roi, Puget, Metz, …) contain structures that share a SIRET but really designate distinct services with important activity counts; fusing them automatically would mix activities that are impossible to disentangle afterwards. The option lets operators run the fusion in production while protecting these specific clusters by passing structure UUIDs (stable, unlike cluster IDs which change at each plan regeneration). If any excluded UUID matches a row in the cluster, the whole cluster is skipped.