### PR TITLE
fix: add BAN score floor and exclusion to coordinate correction

### DIFF
--- a/apps/web/src/jobs/apply-corriger-coordonnees/applyCorrigerCoordonneesJob.ts
+++ b/apps/web/src/jobs/apply-corriger-coordonnees/applyCorrigerCoordonneesJob.ts
@@ -5,6 +5,12 @@ export const ApplyCorrigerCoordonneesJobValidation = z.object({
   payload: z
     .object({
       dryRun: z.boolean().optional().default(true),
+      // Skip these structures (e.g. a BAN match that lands in the wrong
+      // region despite a decent score). Structure UUIDs are stable.
+      excludeStructureIds: z.array(z.string().uuid()).optional(),
+      // Minimum BAN geocoding score to accept a correction. Below this the
+      // match is considered too unreliable and the structure is left as-is.
+      minBanScore: z.number().optional().default(0.65),
     })
     .optional(),
 })

--- a/apps/web/src/jobs/apply-corriger-coordonnees/executeApplyCorrigerCoordonnees.ts
+++ b/apps/web/src/jobs/apply-corriger-coordonnees/executeApplyCorrigerCoordonnees.ts
@@ -64,13 +64,23 @@ export const executeApplyCorrigerCoordonnees = async (
   job: ApplyCorrigerCoordonneesJob,
 ) => {
   const dryRun = job.payload?.dryRun ?? true
+  const minBanScore = job.payload?.minBanScore ?? 0.65
+  const excludeStructureIds = new Set(job.payload?.excludeStructureIds ?? [])
 
   output.log(
-    `apply-corriger-coordonnees: starting${dryRun ? ' (DRY RUN)' : ''}...`,
+    `apply-corriger-coordonnees: starting${dryRun ? ' (DRY RUN)' : ''} (minBanScore: ${minBanScore})...`,
   )
 
   const actionPlan = await readActionPlan()
-  const toFix = filterActionPlan(actionPlan, 'corriger_coordonnees')
+  const allToFix = filterActionPlan(actionPlan, 'corriger_coordonnees')
+  const toFix = allToFix.filter((row) => !excludeStructureIds.has(row.id))
+  const excludedCount = allToFix.length - toFix.length
+
+  if (excludedCount > 0) {
+    output.log(
+      `apply-corriger-coordonnees: ${excludedCount} structures exclues`,
+    )
+  }
 
   output.log(
     `apply-corriger-coordonnees: ${toFix.length} coordonnées à corriger`,
@@ -122,7 +132,7 @@ export const executeApplyCorrigerCoordonnees = async (
       const query = `${structure.adresse}, ${structure.codePostal} ${structure.commune}`
       const feature = await searchAdresse(query)
 
-      if (!feature || feature.properties.score < 0.5) {
+      if (!feature || feature.properties.score < minBanScore) {
         results.push({
           row,
           latActuelle: structure.latitude?.toFixed(6) ?? '',


### PR DESCRIPTION
apply-corriger-coordonnees could apply low-confidence BAN matches that relocated structures to the wrong region (e.g. a Martinique structure moved to mainland France at score 0.518).

- Add minBanScore payload option (default 0.65); the floor was previously hardcoded at 0.5.
- Add excludeStructureIds payload option to skip a structure whose BAN match is wrong despite a decent score.