### PR TITLE
fix: skip dataspace structures with incomplete address

### DIFF
--- a/apps/web/src/features/dataspace/syncFromDataspaceCore.spec.ts
+++ b/apps/web/src/features/dataspace/syncFromDataspaceCore.spec.ts
@@ -1,0 +1,47 @@
+import type { DataspaceMediateurAdresse } from '@app/web/external-apis/dataspace/dataspaceApiClient'
+import { isDataspaceAdresseComplete } from './syncFromDataspaceCore'
+
+const completeAdresse: DataspaceMediateurAdresse = {
+  nom_voie: 'Avenue de Folelli',
+  code_insee: '2B207',
+  repetition: null,
+  code_postal: '20213',
+  nom_commune: 'Penta-di-Casinca',
+  numero_voie: 1,
+}
+
+describe('isDataspaceAdresseComplete', () => {
+  it('returns true when voie, commune, code postal and code insee are all present', () => {
+    expect(isDataspaceAdresseComplete(completeAdresse)).toBe(true)
+  })
+
+  it('returns false when nom_voie is null', () => {
+    expect(
+      isDataspaceAdresseComplete({ ...completeAdresse, nom_voie: null }),
+    ).toBe(false)
+  })
+
+  it('returns false when nom_voie is blank', () => {
+    expect(
+      isDataspaceAdresseComplete({ ...completeAdresse, nom_voie: '   ' }),
+    ).toBe(false)
+  })
+
+  it('returns false when code_insee is empty', () => {
+    expect(
+      isDataspaceAdresseComplete({ ...completeAdresse, code_insee: '' }),
+    ).toBe(false)
+  })
+
+  it('returns false when code_postal is empty', () => {
+    expect(
+      isDataspaceAdresseComplete({ ...completeAdresse, code_postal: '' }),
+    ).toBe(false)
+  })
+
+  it('returns false when nom_commune is empty', () => {
+    expect(
+      isDataspaceAdresseComplete({ ...completeAdresse, nom_commune: '' }),
+    ).toBe(false)
+  })
+})

--- a/apps/web/src/features/dataspace/syncFromDataspaceCore.ts
+++ b/apps/web/src/features/dataspace/syncFromDataspaceCore.ts
@@ -3,6 +3,7 @@ import type {
   DataspaceContrat,
   DataspaceLieuActivite,
   DataspaceMediateur,
+  DataspaceMediateurAdresse,
   DataspaceStructureEmployeuse,
 } from '@app/web/external-apis/dataspace/dataspaceApiClient'
 import { getContractStatus } from '@app/web/features/dataspace/getContractStatus'
@@ -144,6 +145,22 @@ export const getEmploiEndDate = (contrat: DataspaceContrat): Date | null => {
 }
 
 /**
+ * A structure is only synced into the coop when its address is complete enough
+ * to identify a real place (voie + commune + code postal + code insee). When the
+ * Dataspace sends a partial address, geocoding/matching cannot reconcile it with
+ * existing structures and a duplicate gets created on every sync. Skipping these
+ * is the same rule already applied to lieux d'activité. Fixing the source data in
+ * the Dataspace is the only way to get such a structure synced.
+ */
+export const isDataspaceAdresseComplete = (
+  adresse: DataspaceMediateurAdresse,
+): boolean =>
+  Boolean(adresse.nom_voie?.trim()) &&
+  Boolean(adresse.code_insee) &&
+  Boolean(adresse.code_postal) &&
+  Boolean(adresse.nom_commune)
+
+/**
  * Prepare contract data from Dataspace for EmployeStructure sync
  * Returns one PreparedContract for each contract in each structure
  * Creates one EmployeStructure record per contract
@@ -164,6 +181,12 @@ export const prepareContractsFromDataspace = async (
 
     // Skip structures without contracts
     if (contractsWithDebut.length === 0) {
+      continue
+    }
+
+    // Skip structures whose Dataspace address is incomplete (cannot identify a
+    // real place → would create a duplicate on every sync).
+    if (!isDataspaceAdresseComplete(structureEmployeuse.adresse)) {
       continue
     }
 
@@ -274,13 +297,16 @@ export const syncStructuresEmployeusesFromDataspace = async ({
 
   const firstStructureWithNullDebutContract = nonNullStructures.find(
     (structureEmployeuse) =>
+      isDataspaceAdresseComplete(structureEmployeuse.adresse) &&
       (structureEmployeuse.contrats ?? []).some(
         (contract) => contract.date_debut === null,
       ),
   )
 
   const firstStructureWithEmptyContracts = nonNullStructures.find(
-    (structureEmployeuse) => (structureEmployeuse.contrats ?? []).length === 0,
+    (structureEmployeuse) =>
+      isDataspaceAdresseComplete(structureEmployeuse.adresse) &&
+      (structureEmployeuse.contrats ?? []).length === 0,
   )
 
   const temporaryContractTargetStructure =


### PR DESCRIPTION
A structure employeuse arriving from the Dataspace with a partial address (missing voie, commune, code postal or code insee) cannot be reconciled with existing structures, so findOrCreateStructure creates a fresh duplicate on every nightly sync (observed: FIUM ALTU, FALEP, Alata each grew +1/night despite the May matching fix).

Apply the same completeness gate already used for lieux d'activité: a structure is only synced when voie + commune + code postal + code insee are all present. Incomplete payloads are skipped — correcting the source data in the Dataspace is the only way to get such a structure synced.