### PR TITLE
fix: guard opening hours parsing against malformed horaires

### DIFF
--- a/apps/web/src/components/structure/fields/openingHoursHelpers.spec.ts
+++ b/apps/web/src/components/structure/fields/openingHoursHelpers.spec.ts
@@ -1,0 +1,29 @@
+import { CLOSED_SCHEDULE } from '@gouvfr-anct/timetable-to-osm-opening-hours'
+import { safeToTimetableOpeningHours } from './openingHoursHelpers'
+
+describe('safeToTimetableOpeningHours', () => {
+  it('returns an empty week instead of throwing on a malformed unquoted comment', () => {
+    const malformed =
+      'Mo 08:30-12:00 Un Lundi sur deux,calendrier disponible sur https://www.espritquiclic.com/calendrier'
+
+    expect(safeToTimetableOpeningHours(new Date())(malformed)).toEqual(
+      CLOSED_SCHEDULE,
+    )
+  })
+
+  it('returns an empty week for null input', () => {
+    expect(safeToTimetableOpeningHours(new Date())(null)).toEqual(
+      CLOSED_SCHEDULE,
+    )
+  })
+
+  it('parses a valid OSM string', () => {
+    const result = safeToTimetableOpeningHours(new Date())('Mo 08:30-12:00')
+
+    expect(result.Mo.am).toEqual({
+      startTime: '08:30',
+      endTime: '12:00',
+      isOpen: true,
+    })
+  })
+})

--- a/apps/web/src/components/structure/fields/openingHoursHelpers.ts
+++ b/apps/web/src/components/structure/fields/openingHoursHelpers.ts
@@ -1,4 +1,9 @@
-import { OsmDaysOfWeek } from '@gouvfr-anct/timetable-to-osm-opening-hours'
+import {
+  CLOSED_SCHEDULE,
+  OsmDaysOfWeek,
+  Schedule,
+  toTimetableOpeningHours,
+} from '@gouvfr-anct/timetable-to-osm-opening-hours'
 
 export type Period = 'am' | 'pm'
 
@@ -41,6 +46,18 @@ export const emptyOpeningHours = {
   Sa: defaultOpeningHours,
   Su: defaultOpeningHours,
 }
+
+// The OSM parser throws on malformed `horaires` (e.g. an unquoted comment
+// stored from imports). Fall back to an empty week instead of crashing render.
+export const safeToTimetableOpeningHours =
+  (date: Date) =>
+  (horairesOSM: string | null): Schedule => {
+    try {
+      return toTimetableOpeningHours(date)(horairesOSM ?? undefined)
+    } catch {
+      return CLOSED_SCHEDULE
+    }
+  }
 
 export const appendComment = (
   osmOpeningHours: string,

--- a/apps/web/src/features/lieux-activite/components/informations-pratiques/InformationsPratiquesEditCard.tsx
+++ b/apps/web/src/features/lieux-activite/components/informations-pratiques/InformationsPratiquesEditCard.tsx
@@ -3,7 +3,10 @@
 import { createToast } from '@app/ui/toast/createToast'
 import EditCard from '@app/web/components/EditCard'
 import { InformationsPratiquesFields } from '@app/web/components/structure/fields/InformationsPratiquesFields'
-import { appendComment } from '@app/web/components/structure/fields/openingHoursHelpers'
+import {
+  appendComment,
+  safeToTimetableOpeningHours,
+} from '@app/web/components/structure/fields/openingHoursHelpers'
 import { withTrpc } from '@app/web/components/trpc/withTrpc'
 import {
   InformationsPratiquesData,
@@ -15,7 +18,6 @@ import { isEmpty } from '@app/web/utils/isEmpty'
 import {
   fromTimetableOpeningHours,
   Schedule,
-  toTimetableOpeningHours,
 } from '@gouvfr-anct/timetable-to-osm-opening-hours'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { useRouter } from 'next/navigation'
@@ -49,7 +51,7 @@ const InformationsPratiquesEditCard = ({
       openingHours:
         horaires == null || horaires === ''
           ? undefined
-          : toTimetableOpeningHours(new Date())(horaires),
+          : safeToTimetableOpeningHours(new Date())(horaires),
       horairesComment: horaires?.match(/".+"/g)?.toString().replaceAll('"', ''),
     },
   })

--- a/apps/web/src/features/lieux-activite/components/informations-pratiques/OpeningHours.tsx
+++ b/apps/web/src/features/lieux-activite/components/informations-pratiques/OpeningHours.tsx
@@ -1,7 +1,5 @@
-import {
-  NullableTime,
-  toTimetableOpeningHours,
-} from '@gouvfr-anct/timetable-to-osm-opening-hours'
+import { safeToTimetableOpeningHours } from '@app/web/components/structure/fields/openingHoursHelpers'
+import { NullableTime } from '@gouvfr-anct/timetable-to-osm-opening-hours'
 import classNames from 'classnames'
 
 const JOURS_DE_LA_SEMAINE = ['Lun', 'Mar', 'Mer', 'Jeu', 'Ven', 'Sam', 'Dim']
@@ -34,7 +32,7 @@ export const OpeningHours = ({
       'fr-flex fr-direction-column fr-flex-gap-2v',
     )}
   >
-    {Object.entries(toTimetableOpeningHours(new Date())(horaires)).map(
+    {Object.entries(safeToTimetableOpeningHours(new Date())(horaires)).map(
       ([day, daySchedule], index) => (
         <div key={day} className="fr-flex fr-flex-gap-4v">
           <span className="fr-text--medium" style={{ width: '38px' }}>


### PR DESCRIPTION
Wrap toTimetableOpeningHours in a safe helper that returns an empty week when the OSM parser throws on a malformed horaires string (e.g. an unquoted comment from imports), preventing a 500 when viewing or editing a lieu d'activite.