### PR TITLE
fix: align fin/suppression display and active link counts in admin

### DIFF
--- a/apps/web/src/app/administration/utilisateurs/[id]/AdministrationUserPage.tsx
+++ b/apps/web/src/app/administration/utilisateurs/[id]/AdministrationUserPage.tsx
@@ -758,28 +758,30 @@ const AdministrationUserPage = async ({
         )}
         {enActivite.length > 0 ? (
           <AdministrationInfoCard title="Lieux d’activité">
-            {enActivite.map((activite) => (
-              <div key={activite.id}>
-                <p className="fr-text--lg fr-text--medium fr-mb-4v fr-mt-8v">
-                  {activite.structure.nom}
-                </p>
-                <AdministrationInlineLabelsValues
-                  items={[
-                    ...getStructuresInfos(activite.structure),
-                    {
-                      label: 'Lien d’activité créé le',
-                      value: dateAsDay(activite.creation),
-                    },
-                    {
-                      label: 'Lien d’activité supprimé le',
-                      value: activite.suppression
-                        ? dateAsDay(activite.suppression)
-                        : '-',
-                    },
-                  ]}
-                />
-              </div>
-            ))}
+            {enActivite.map((activite) => {
+              const finLien = activite.suppression ?? activite.fin
+
+              return (
+                <div key={activite.id}>
+                  <p className="fr-text--lg fr-text--medium fr-mb-4v fr-mt-8v">
+                    {activite.structure.nom}
+                  </p>
+                  <AdministrationInlineLabelsValues
+                    items={[
+                      ...getStructuresInfos(activite.structure),
+                      {
+                        label: 'Lien d’activité créé le',
+                        value: dateAsDay(activite.creation),
+                      },
+                      {
+                        label: 'Lien d’activité supprimé le',
+                        value: finLien ? dateAsDay(finLien) : '-',
+                      },
+                    ]}
+                  />
+                </div>
+              )
+            })}
           </AdministrationInfoCard>
         ) : (
           !!mediateur && (

--- a/apps/web/src/features/structures/use-cases/list/queryStructuresForList.ts
+++ b/apps/web/src/features/structures/use-cases/list/queryStructuresForList.ts
@@ -17,8 +17,14 @@ export const searchStructureSelect = {
   suppression: true,
   _count: {
     select: {
-      emplois: true,
-      mediateursEnActivite: true,
+      emplois: { where: { suppression: null } },
+      mediateursEnActivite: {
+        where: {
+          suppression: null,
+          fin: null,
+          mediateur: { user: { deleted: null } },
+        },
+      },
     },
   },
 } satisfies Prisma.StructureSelect


### PR DESCRIPTION
- admin user lieux: show suppression ?? fin as 'supprimé le' date so links ended via lieu removal (fin only) no longer display '-'
- structures list: filter _count to active links only (suppression null, fin null, user not deleted for mediateurs; suppression null for emplois) so the 'Médiateurs en activité' count and 'Lieu d'activité'/'Employeuse' tags match the detail view