### PR TITLE
fix: auto-bump modification/updated via prisma client extension

### DIFF
--- a/apps/web/src/prisma/timestampExtension.integration.ts
+++ b/apps/web/src/prisma/timestampExtension.integration.ts
@@ -1,0 +1,177 @@
+import { prismaClient } from '@app/web/prismaClient'
+
+// Vérifie le comportement de l'extension qui pose automatiquement `modification` / `updated`.
+// Ces tests confirment aussi la casse des clés de la carte (un échec de bump = mauvaise casse).
+
+const wait = (ms: number) =>
+  new Promise((resolve) => {
+    setTimeout(resolve, ms)
+  })
+
+const apiClientId = '00000000-0000-0000-0000-00000000a001'
+const userId = '00000000-0000-0000-0000-00000000a002'
+const mediateurId = '00000000-0000-0000-0000-00000000a003'
+
+const cleanup = async () => {
+  await prismaClient.mediateur.deleteMany({ where: { id: mediateurId } })
+  await prismaClient.user.deleteMany({ where: { id: userId } })
+  await prismaClient.apiClient.deleteMany({ where: { id: apiClientId } })
+}
+
+describe('timestampExtension', () => {
+  beforeAll(async () => {
+    await cleanup()
+    await prismaClient.apiClient.create({
+      data: {
+        id: apiClientId,
+        name: 'timestamp-extension-test-client',
+        secretHash: 'test-hash',
+        validFrom: new Date(),
+      },
+    })
+    await prismaClient.user.create({
+      data: { id: userId, email: 'timestamp-extension-test@example.com' },
+    })
+    await prismaClient.mediateur.create({ data: { id: mediateurId, userId } })
+  })
+
+  afterAll(async () => {
+    await cleanup()
+    await prismaClient.$disconnect()
+  })
+
+  describe('modèle suivi via champ `updated` (ApiClient)', () => {
+    it('bumpe `updated` sur un update de contenu', async () => {
+      const before = await prismaClient.apiClient.findUniqueOrThrow({
+        where: { id: apiClientId },
+      })
+
+      await wait(50)
+      const updated = await prismaClient.apiClient.update({
+        where: { id: apiClientId },
+        data: { validUntil: new Date() },
+      })
+
+      expect(updated.updated.getTime()).toBeGreaterThan(
+        before.updated.getTime(),
+      )
+    })
+
+    it('bumpe `updated` même à l’intérieur d’une transaction interactive', async () => {
+      const before = await prismaClient.apiClient.findUniqueOrThrow({
+        where: { id: apiClientId },
+      })
+
+      await wait(50)
+      await prismaClient.$transaction(async (transaction) => {
+        await transaction.apiClient.update({
+          where: { id: apiClientId },
+          data: { validUntil: new Date() },
+        })
+      })
+
+      const after = await prismaClient.apiClient.findUniqueOrThrow({
+        where: { id: apiClientId },
+      })
+      expect(after.updated.getTime()).toBeGreaterThan(before.updated.getTime())
+    })
+
+    it('bumpe `updated` sur la branche update d’un upsert', async () => {
+      const before = await prismaClient.apiClient.findUniqueOrThrow({
+        where: { id: apiClientId },
+      })
+
+      await wait(50)
+      await prismaClient.apiClient.upsert({
+        where: { id: apiClientId },
+        update: { validUntil: new Date() },
+        create: {
+          id: apiClientId,
+          name: 'timestamp-extension-test-client',
+          secretHash: 'test-hash',
+          validFrom: new Date(),
+        },
+      })
+
+      const after = await prismaClient.apiClient.findUniqueOrThrow({
+        where: { id: apiClientId },
+      })
+      expect(after.updated.getTime()).toBeGreaterThan(before.updated.getTime())
+    })
+
+    it('respecte une valeur `updated` posée explicitement par l’appelant', async () => {
+      const explicit = new Date('2020-01-01T00:00:00.000Z')
+
+      const updated = await prismaClient.apiClient.update({
+        where: { id: apiClientId },
+        data: { updated: explicit, validUntil: new Date() },
+      })
+
+      expect(updated.updated.getTime()).toBe(explicit.getTime())
+    })
+  })
+
+  describe('modèle suivi via champ `modification` (Mediateur)', () => {
+    it('bumpe `modification` sur un update de contenu', async () => {
+      const before = await prismaClient.mediateur.findUniqueOrThrow({
+        where: { id: mediateurId },
+      })
+
+      await wait(50)
+      const updated = await prismaClient.mediateur.update({
+        where: { id: mediateurId },
+        data: { isVisible: true },
+      })
+
+      expect(updated.modification.getTime()).toBeGreaterThan(
+        before.modification.getTime(),
+      )
+    })
+
+    it('ne bumpe PAS `modification` si seul un compteur change', async () => {
+      const before = await prismaClient.mediateur.findUniqueOrThrow({
+        where: { id: mediateurId },
+      })
+
+      await wait(50)
+      const updated = await prismaClient.mediateur.update({
+        where: { id: mediateurId },
+        data: { activitesCount: { increment: 1 } },
+      })
+
+      expect(updated.modification.getTime()).toBe(before.modification.getTime())
+    })
+  })
+
+  describe('cas particulier User : suivi de session', () => {
+    it('bumpe `updated` sur un update de contenu', async () => {
+      const before = await prismaClient.user.findUniqueOrThrow({
+        where: { id: userId },
+      })
+
+      await wait(50)
+      const updated = await prismaClient.user.update({
+        where: { id: userId },
+        data: { firstName: 'Test' },
+      })
+
+      expect(updated.updated.getTime()).toBeGreaterThan(
+        before.updated.getTime(),
+      )
+    })
+
+    it('ne bumpe PAS `updated` si seul `lastSeen` change', async () => {
+      const before = await prismaClient.user.findUniqueOrThrow({
+        where: { id: userId },
+      })
+
+      await wait(50)
+      const updated = await prismaClient.user.update({
+        where: { id: userId },
+        data: { lastSeen: new Date() },
+      })
+
+      expect(updated.updated.getTime()).toBe(before.updated.getTime())
+    })
+  })
+})

--- a/apps/web/src/prisma/timestampExtension.ts
+++ b/apps/web/src/prisma/timestampExtension.ts
@@ -1,0 +1,91 @@
+import { Prisma } from '@prisma/client'
+
+// Extension Prisma qui pose automatiquement la date de dernière modification
+// (`modification` ou `updated` selon le modèle) sur chaque update/updateMany/upsert.
+// Ces colonnes ne sont PAS auto-gérées par Prisma (pas de `@updatedAt`) : sans cette
+// extension le bump est manuel et donc oublié sur de nombreux chemins (fusions, jobs,
+// fins d'emploi/activité…). Les tables `Rdv*` (auto-gérées via `@updatedAt`) et les
+// tables sans champ de modification ne figurent pas dans la carte et sont ignorées.
+
+type TimestampField = 'modification' | 'updated'
+
+// Carte modèle (PascalCase, tel que fourni par l'extension) → champ à poser.
+const MODIFICATION_FIELD: Record<string, TimestampField> = {
+  Activite: 'modification',
+  ActiviteCoordination: 'modification',
+  Tag: 'modification',
+  Structure: 'modification',
+  StructureCartographieNationale: 'modification',
+  Mediateur: 'modification',
+  Coordinateur: 'modification',
+  MediateurCoordonne: 'modification',
+  MediateurEnActivite: 'modification',
+  EmployeStructure: 'modification',
+  Beneficiaire: 'modification',
+  User: 'updated',
+  ApiClient: 'updated',
+  AssistantChatThread: 'updated',
+  RagDocumentChunk: 'updated',
+}
+
+// Champs « non-contenu » : compteurs dénormalisés et marqueurs techniques. Si une mise à
+// jour ne touche QUE ces champs, on ne bumpe pas (ex. recompte de `activitesCount`, ou
+// `lastSeen`/`lastLogin`) — aligné sur le défaut de Rails counter_culture, et évite que
+// la synchro carto voie une structure « modifiée » à chaque activité loggée.
+const NON_CONTENT_FIELDS = new Set<string>([
+  'activitesCount',
+  'accompagnementsCount',
+  'beneficiairesCount',
+  'derniereCreationActivite',
+  'derniereCreationBeneficiaire',
+  'lastLogin',
+  'lastSeen',
+])
+
+const withTimestamp = (
+  model: string,
+  data: Record<string, unknown> | undefined,
+): Record<string, unknown> | undefined => {
+  const field = MODIFICATION_FIELD[model]
+
+  // Modèle non suivi, data absente, ou champ déjà posé explicitement par l'appelant
+  // (ex. fusionnerBeneficiaires qui fixe `modification` lui-même) → on n'y touche pas.
+  if (!field || data == null || field in data) {
+    return data
+  }
+
+  // Mise à jour ne touchant que des champs non-contenu → pas de bump.
+  const keys = Object.keys(data)
+  if (keys.length > 0 && keys.every((key) => NON_CONTENT_FIELDS.has(key))) {
+    return data
+  }
+
+  return { ...data, [field]: new Date() }
+}
+
+// NB : les hooks `$allModels` n'interceptent QUE l'opération de premier niveau. Les
+// écritures imbriquées via relation (ex. `mediateur.update({ data: { user: { update } } })`)
+// ne sont pas auto-bumpées et doivent poser le champ manuellement, comme c'est déjà le cas.
+// De même, le SQL pur (`$executeRaw`) n'est pas intercepté (géré manuellement).
+export const timestampExtension = Prisma.defineExtension({
+  name: 'auto-modification-timestamp',
+  query: {
+    $allModels: {
+      update({ model, args, query }) {
+        const data = withTimestamp(model, args.data as Record<string, unknown>)
+        return query({ ...args, data } as typeof args)
+      },
+      updateMany({ model, args, query }) {
+        const data = withTimestamp(model, args.data as Record<string, unknown>)
+        return query({ ...args, data } as typeof args)
+      },
+      upsert({ model, args, query }) {
+        const update = withTimestamp(
+          model,
+          args.update as Record<string, unknown>,
+        )
+        return query({ ...args, update } as typeof args)
+      },
+    },
+  },
+})

--- a/apps/web/src/prismaClient.ts
+++ b/apps/web/src/prismaClient.ts
@@ -1,14 +1,9 @@
+import { timestampExtension } from '@app/web/prisma/timestampExtension'
 import { PrismaClient } from '@prisma/client'
-
-// https://www.prisma.io/docs/guides/other/troubleshooting-orm/help-articles/nextjs-prisma-client-dev-practices
-const globalForPrisma = global as unknown as {
-  prismaClient: PrismaClient | undefined
-}
 
 const debugLog = process.env.PRISMA_ENABLE_LOGGING === '1'
 
-export const prismaClient =
-  globalForPrisma.prismaClient ??
+const createPrismaClient = () =>
   new PrismaClient({
     log: debugLog
       ? [
@@ -30,7 +25,20 @@ export const prismaClient =
           },
         ]
       : undefined,
-  })
+  }).$extends(timestampExtension)
+
+// https://www.prisma.io/docs/guides/other/troubleshooting-orm/help-articles/nextjs-prisma-client-dev-practices
+const globalForPrisma = global as unknown as {
+  prismaClient: PrismaClient | undefined
+}
+
+// `timestampExtension` n'ajoute qu'un hook `query` (aucune méthode/type supplémentaire sur le
+// client) : la surface de type reste identique à `PrismaClient`. On conserve donc ce type pour
+// l'export afin de ne pas propager le type du client étendu à toutes les signatures
+// consommatrices (`tx: Prisma.TransactionClient`, etc.) ; le hook s'exécute bien au runtime.
+export const prismaClient =
+  globalForPrisma.prismaClient ??
+  (createPrismaClient() as unknown as PrismaClient)
 
 if (process.env.NODE_ENV !== 'production') {
   globalForPrisma.prismaClient = prismaClient


### PR DESCRIPTION
Les colonnes de date de derniere modification (modification/updated) ne sont pas auto-gerees par Prisma (pas de @updatedAt) : le bump etait manuel et donc oublie sur de nombreux chemins (fusions, jobs de maintenance, fins d'emploi/activite, edition de beneficiaire...).

Ajoute une client extension query sur $allModels qui pose automatiquement le champ sur update/updateMany/upsert pour les 15 modeles concernes, avec :
- exemption des champs non-contenu (compteurs denormalises, lastLogin, lastSeen) : une ecriture qui ne touche que ces champs ne bumpe pas ;
- respect d'une valeur posee explicitement par l'appelant.

Le SQL pur ($executeRaw) et les ecritures imbriquees via relation restent geres manuellement (non interceptes par $allModels).

Le type exporte reste PrismaClient (l'extension n'ajoute aucune API), donc aucune signature consommatrice n'est impactee.