### PR TITLE
feat(tmp): add /tmp page validating Dataspace admin schema presence

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -101,6 +101,17 @@ DATASPACE_BACKUP_DATABASE_NAME="dataspace_prod"
 ## prod connection string as a secret (never commit it here).
 ENTREPOT_DATABASE_URL="<secret>"
 
+## SSH tunnel used by DEPLOYED containers to reach the entrepôt's private endpoint through MIN's
+## bastion (see docker/web/entrypoint.sh). Empty → the entrypoint skips the tunnel (no-op), which
+## is the local case (entrepotPrismaClient falls back to DATABASE_URL). To activate on deployed
+## envs: fill the bastion host/user/port (NOT secret) once MIN provides them, and create
+## ENTREPOT_BASTION_SSH_KEY in the Scaleway Secret Manager. ENTREPOT_DATABASE_URL then targets the
+## tunnel: postgres://<ro>:<pwd>@localhost:5433/dataspace_prod?sslmode=require
+ENTREPOT_BASTION_HOST=""
+ENTREPOT_BASTION_USER=""
+ENTREPOT_BASTION_PORT="22"
+ENTREPOT_BASTION_SSH_KEY="<secret>"
+
 # Object storage credentials
 S3_HOST=s3.fr-par.scw.cloud
 UPLOADS_BUCKET=${NEXT_PUBLIC_APP_SLUG}-developer-unsafe-uploads

--- a/.env.dist
+++ b/.env.dist
@@ -105,8 +105,9 @@ ENTREPOT_DATABASE_URL="<secret>"
 ## bastion (see docker/web/entrypoint.sh). Empty → the entrypoint skips the tunnel (no-op), which
 ## is the local case (entrepotPrismaClient falls back to DATABASE_URL). To activate on deployed
 ## envs: fill the bastion host/user/port (NOT secret) once MIN provides them, and create
-## ENTREPOT_BASTION_SSH_KEY in the Scaleway Secret Manager. ENTREPOT_DATABASE_URL then targets the
-## tunnel: postgres://<ro>:<pwd>@localhost:5433/dataspace_prod?sslmode=require
+## ENTREPOT_BASTION_SSH_KEY in the Scaleway Secret Manager — its value is the BASE64 of the private
+## key (single line: `base64 -w0 entrepot_bastion_key`), which the entrypoint decodes back.
+## ENTREPOT_DATABASE_URL then targets the tunnel: postgres://<ro>:<pwd>@localhost:5433/dataspace_prod?sslmode=require
 ENTREPOT_BASTION_HOST=""
 ENTREPOT_BASTION_USER=""
 ENTREPOT_BASTION_PORT="22"

--- a/.env.dist
+++ b/.env.dist
@@ -95,6 +95,12 @@ DATASPACE_API_KEY="<secret>"
 DATASPACE_DATABASE_INSTANCE_ID="fr-par/05720630-2c09-4bbe-a436-885bae61162c"
 DATASPACE_BACKUP_DATABASE_NAME="dataspace_prod"
 
+## Live connection to the entrepôt (Dataspace) database for the cohabiting schemas
+## (admin/main/reference/audit), read-only. Leave UNSET locally: it falls back to DATABASE_URL,
+## since the dev container already hosts every schema. Deployed environments inject the entrepôt
+## prod connection string as a secret (never commit it here).
+ENTREPOT_DATABASE_URL="<secret>"
+
 # Object storage credentials
 S3_HOST=s3.fr-par.scw.cloud
 UPLOADS_BUCKET=${NEXT_PUBLIC_APP_SLUG}-developer-unsafe-uploads

--- a/apps/cli/src/commands/infrastructure/createTfVarsFileFromEnvironment.ts
+++ b/apps/cli/src/commands/infrastructure/createTfVarsFileFromEnvironment.ts
@@ -4,36 +4,52 @@ import { output } from '@app/cli/output'
 import { getDirname } from '@app/config/dirname'
 import { Argument, Command } from '@commander-js/extra-typings'
 
-const { webAppStackVariables, webAppStackSensitiveVariables } = await import(
-  '@app/cdk/WebAppStack'
-)
+const {
+  webAppStackVariables,
+  webAppStackSensitiveVariables,
+  webAppStackEntrepotVariables,
+  webAppStackEntrepotSensitiveVariables,
+} = await import('@app/cdk/WebAppStack')
 
 // See https://developer.hashicorp.com/terraform/language/values/variables#variable-definitions-tfvars-files
 export const createTfVarsFileFromEnvironment = new Command()
   .command('terraform:vars-from-env')
   .addArgument(new Argument('<stack>', 'CDK Stack').choices(['web']))
   .action(async (stack) => {
-    const variableNames =
+    const requiredNames =
       stack === 'web'
         ? [...webAppStackVariables, ...webAppStackSensitiveVariables]
         : null
 
-    if (!variableNames) {
+    if (!requiredNames) {
       throw new Error('Invalid stack argument')
     }
 
-    const variables = Object.fromEntries(
-      variableNames.map((name) => {
-        const value = process.env[name]
-        if (!value) {
-          throw new Error(
-            `Variable ${name} is not present in environment but needed as a terraform variable for "${stack}" stack`,
-          )
-        }
+    // Optional variables (e.g. the entrepôt SSH tunnel) are emitted only when set; otherwise the
+    // CDK default ('') applies, so they never block a deployment that hasn't configured them yet.
+    const optionalNames = [
+      ...webAppStackEntrepotVariables,
+      ...webAppStackEntrepotSensitiveVariables,
+    ]
 
-        return [name, value]
-      }),
-    )
+    const requiredVariables = requiredNames.map((name) => {
+      const value = process.env[name]
+      if (!value) {
+        throw new Error(
+          `Variable ${name} is not present in environment but needed as a terraform variable for "${stack}" stack`,
+        )
+      }
+      return [name, value] as const
+    })
+
+    const optionalVariables = optionalNames
+      .map((name) => [name, process.env[name]] as const)
+      .filter(([, value]) => Boolean(value))
+
+    const variables = Object.fromEntries([
+      ...requiredVariables,
+      ...optionalVariables,
+    ])
 
     const tfVariablesFile = path.resolve(
       getDirname(import.meta.url),
@@ -42,6 +58,6 @@ export const createTfVarsFileFromEnvironment = new Command()
     await writeFile(tfVariablesFile, JSON.stringify(variables, null, 2))
 
     output(
-      `The ${variableNames.length} terraform variables for stack ${stack} have been added to ${tfVariablesFile}`,
+      `The ${Object.keys(variables).length} terraform variables for stack ${stack} have been added to ${tfVariablesFile}`,
     )
   })

--- a/apps/web/src/app/tmp/page.tsx
+++ b/apps/web/src/app/tmp/page.tsx
@@ -1,0 +1,101 @@
+import { metadataTitle } from '@app/web/app/metadataTitle'
+import { entrepotPrismaClient } from '@app/web/entrepotPrismaClient'
+import { prismaClient } from '@app/web/prismaClient'
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  title: metadataTitle('Validation entrepôt - communes'),
+}
+
+// Page de validation temporaire. Vérifie que les DEUX connexions cohabitent : la base Coop
+// (schéma `coop`, via `prismaClient`) et la base de l'entrepôt Dataspace (schémas `admin/main/…`,
+// via `entrepotPrismaClient`). Le compte de `admin.commune` prouve que l'entrepôt est branché.
+// Affiche le `current_database()` de chaque connexion pour repérer une mauvaise cible. Tolère
+// l'absence du schéma (environnement encore branché sur la seule base Coop).
+export const dynamic = 'force-dynamic'
+
+const errorMessage = (error: unknown) =>
+  error instanceof Error ? error.message : String(error)
+
+const currentDatabase = (client: typeof prismaClient): Promise<string | null> =>
+  client.$queryRaw<
+    { database: string }[]
+  >`SELECT current_database() AS database`
+    .then(([row]) => row?.database ?? null)
+    .catch(() => null)
+
+type Communes = { ok: true; count: number } | { ok: false; error: string }
+
+const countCommunes = (): Promise<Communes> =>
+  entrepotPrismaClient.$queryRaw<
+    { count: number }[]
+  >`SELECT count(*)::int AS count FROM admin.commune`
+    .then((rows): Communes => ({ ok: true, count: rows[0]?.count ?? 0 }))
+    .catch((error): Communes => ({ ok: false, error: errorMessage(error) }))
+
+const getValidationData = async () => {
+  const [coopDatabase, entrepotDatabase, communes] = await Promise.all([
+    currentDatabase(prismaClient),
+    currentDatabase(entrepotPrismaClient),
+    countCommunes(),
+  ])
+  return { coopDatabase, entrepotDatabase, communes }
+}
+
+const TmpValidationPage = async () => {
+  const { coopDatabase, entrepotDatabase, communes } = await getValidationData()
+
+  return (
+    <main className="fr-container fr-my-8w">
+      <h1>Validation entrepôt : cohabitation des connexions</h1>
+      <p className="fr-text--lead">
+        Compte des communes dans <code>admin.commune</code> via la connexion
+        entrepôt, base Coop conservée en parallèle.
+      </p>
+
+      <div className="fr-grid-row fr-grid-row--gutters fr-mb-4w">
+        <div className="fr-col-12 fr-col-md-6">
+          <p className="fr-text--sm fr-text-mention--grey fr-mb-1v">
+            Connexion Coop (<code>prismaClient</code>)
+          </p>
+          <code>{coopDatabase ?? 'injoignable'}</code>
+        </div>
+        <div className="fr-col-12 fr-col-md-6">
+          <p className="fr-text--sm fr-text-mention--grey fr-mb-1v">
+            Connexion entrepôt (<code>entrepotPrismaClient</code>)
+          </p>
+          <code>{entrepotDatabase ?? 'injoignable'}</code>
+        </div>
+      </div>
+
+      {communes.ok ? (
+        <div className="fr-callout">
+          <h2 className="fr-callout__title">
+            {communes.count.toLocaleString('fr-FR')} communes
+          </h2>
+          <p className="fr-callout__text">
+            <span className="fr-badge fr-badge--success">
+              Schéma&ensp;<i>admin</i>&ensp;présent
+            </span>{' '}
+            L’entrepôt est branché et la table <i>admin.commune</i> est
+            accessible sur cet environnement.
+          </p>
+        </div>
+      ) : (
+        <div className="fr-callout">
+          <h2 className="fr-callout__title">Schéma indisponible</h2>
+          <p className="fr-callout__text">
+            <span className="fr-badge fr-badge--error">
+              Schéma&ensp;<i>admin</i>&ensp;absent
+            </span>{' '}
+            La table <i>admin.commune</i> n’a pas pu être lue : l’entrepôt n’est
+            probablement pas (encore) branché sur cet environnement.
+          </p>
+          <pre className="fr-text--xs">{communes.error}</pre>
+        </div>
+      )}
+    </main>
+  )
+}
+
+export default TmpValidationPage

--- a/apps/web/src/entrepotPrismaClient.ts
+++ b/apps/web/src/entrepotPrismaClient.ts
@@ -1,0 +1,26 @@
+import { PrismaClient } from '@prisma/client'
+
+// Second Prisma client pointing at the entrepôt (Dataspace) database. Used for raw, read-only
+// queries on the schemas hosted there (admin/main/reference/audit/…); the coop schema keeps
+// using `prismaClient`. Locally ENTREPOT_DATABASE_URL is left as a placeholder and falls back to
+// DATABASE_URL — the dev container already hosts every schema. Deployed environments inject the
+// entrepôt prod connection string. Always schema-qualify tables in queries (e.g. `admin.commune`).
+// Only a real postgres URL is honoured, so the `<secret>` placeholder from .env.dist falls back.
+const configuredEntrepotUrl = process.env.ENTREPOT_DATABASE_URL
+const entrepotDatabaseUrl = configuredEntrepotUrl?.startsWith('postgres')
+  ? configuredEntrepotUrl
+  : process.env.DATABASE_URL
+
+const createEntrepotPrismaClient = () =>
+  new PrismaClient({ datasourceUrl: entrepotDatabaseUrl })
+
+const globalForEntrepot = global as unknown as {
+  entrepotPrismaClient: PrismaClient | undefined
+}
+
+export const entrepotPrismaClient =
+  globalForEntrepot.entrepotPrismaClient ?? createEntrepotPrismaClient()
+
+if (process.env.NODE_ENV !== 'production') {
+  globalForEntrepot.entrepotPrismaClient = entrepotPrismaClient
+}

--- a/docker/web/Dockerfile
+++ b/docker/web/Dockerfile
@@ -2,7 +2,11 @@ FROM node:25.4-slim
 
 WORKDIR /app
 
-RUN apt-get update && apt-get install -y openssl dumb-init
+# openssl + dumb-init for the runtime; autossh + openssh-client to tunnel to the entrepôt
+# database through MIN's bastion (see entrypoint.sh). Cleaned up to keep the image small.
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends openssl dumb-init autossh openssh-client \
+ && rm -rf /var/lib/apt/lists/*
 
 ENV PORT 8080
 ENV NODE_ENV production
@@ -24,6 +28,10 @@ COPY apps/web/.next/static ./apps/web/.next/static
 
 EXPOSE $PORT
 
-ENTRYPOINT ["dumb-init", "--"]
+# Entrypoint opens the entrepôt SSH tunnel (when configured) before exec-ing the CMD below.
+COPY docker/web/entrypoint.sh /app/entrypoint.sh
+RUN chmod +x /app/entrypoint.sh
+
+ENTRYPOINT ["dumb-init", "--", "/app/entrypoint.sh"]
 
 CMD ["node", "./apps/web/server.js"]

--- a/docker/web/entrypoint.sh
+++ b/docker/web/entrypoint.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+# Optionally open an SSH tunnel to the entrepôt (Dataspace) database before starting the app.
+#
+# The entrepôt PostgreSQL instance only exposes a PRIVATE endpoint, reachable through MIN's
+# bastion. We forward a local port to it so the app can read the cohabiting schemas
+# (admin/main/reference/audit) via `ENTREPOT_DATABASE_URL` pointing at localhost.
+#
+# - No-op when ENTREPOT_BASTION_HOST is unset → environments without entrepôt access start as
+#   before, nothing changes for them.
+# - Fail-soft: a tunnel that fails to come up NEVER blocks the Coop app (which uses its own
+#   DATABASE_URL); only the entrepôt-backed pages (e.g. /tmp) degrade until the tunnel is up.
+set -e
+
+if [ -n "${ENTREPOT_BASTION_HOST}" ]; then
+  key_file="$(mktemp)"
+  printf '%s\n' "${ENTREPOT_BASTION_SSH_KEY}" >"${key_file}"
+  chmod 600 "${key_file}"
+
+  echo "[entrypoint] opening entrepôt SSH tunnel via ${ENTREPOT_BASTION_USER}@${ENTREPOT_BASTION_HOST}"
+  AUTOSSH_GATETIME=0 autossh -M 0 -f -N \
+    -o StrictHostKeyChecking=accept-new \
+    -o UserKnownHostsFile=/tmp/known_hosts \
+    -o ServerAliveInterval=30 \
+    -o ServerAliveCountMax=3 \
+    -o ExitOnForwardFailure=yes \
+    -i "${key_file}" \
+    -p "${ENTREPOT_BASTION_PORT:-22}" \
+    -L "${ENTREPOT_TUNNEL_PORT:-5433}:${ENTREPOT_DB_HOST}:${ENTREPOT_DB_PORT:-5432}" \
+    "${ENTREPOT_BASTION_USER}@${ENTREPOT_BASTION_HOST}" &&
+    echo "[entrypoint] autossh tunnel started" ||
+    echo "[entrypoint] WARNING: autossh tunnel failed to start — entrepôt pages unavailable"
+fi
+
+exec "$@"

--- a/docker/web/entrypoint.sh
+++ b/docker/web/entrypoint.sh
@@ -13,7 +13,9 @@ set -e
 
 if [ -n "${ENTREPOT_BASTION_HOST}" ]; then
   key_file="$(mktemp)"
-  printf '%s\n' "${ENTREPOT_BASTION_SSH_KEY}" >"${key_file}"
+  # ENTREPOT_BASTION_SSH_KEY holds the base64-encoded private key (single line — survives passing
+  # through .env, tfvars JSON and the container env); decode it back to a real key file.
+  printf '%s' "${ENTREPOT_BASTION_SSH_KEY}" | base64 -d >"${key_file}"
   chmod 600 "${key_file}"
 
   echo "[entrypoint] opening entrepôt SSH tunnel via ${ENTREPOT_BASTION_USER}@${ENTREPOT_BASTION_HOST}"

--- a/packages/cdk/src/WebAppStack.ts
+++ b/packages/cdk/src/WebAppStack.ts
@@ -1,5 +1,8 @@
 import { createJobExecutionCron } from '@app/cdk/createJobExecutionCron'
-import { environmentVariablesFromList } from '@app/cdk/environmentVariable'
+import {
+  environmentVariablesFromList,
+  optionalEnvironmentVariablesFromList,
+} from '@app/cdk/environmentVariable'
 import { WebCdkOutput } from '@app/cdk/getCdkOutput'
 import { createOutput } from '@app/cdk/output'
 import { terraformBackend } from '@app/cdk/terraformBackend'
@@ -71,6 +74,18 @@ export const webAppStackSensitiveVariables = [
   'DATASPACE_API_KEY',
 ] as const
 
+// Entrepôt (Dataspace) SSH tunnel parameters. OPTIONAL — empty until MIN provides the bastion +
+// read-only credentials; the container entrypoint then opens the tunnel, otherwise it no-ops.
+export const webAppStackEntrepotVariables = [
+  'ENTREPOT_BASTION_HOST',
+  'ENTREPOT_BASTION_USER',
+  'ENTREPOT_BASTION_PORT',
+] as const
+export const webAppStackEntrepotSensitiveVariables = [
+  'ENTREPOT_BASTION_SSH_KEY',
+  'ENTREPOT_DATABASE_URL',
+] as const
+
 /**
  * This stack represents the web app for a given branch (namespace).
  * It can be deployed for each branch.
@@ -100,6 +115,16 @@ export class WebAppStack extends TerraformStack {
     const sensitiveEnvironmentVariables = environmentVariablesFromList(
       this,
       webAppStackSensitiveVariables,
+      { sensitive: true },
+    )
+    const entrepotVariables = optionalEnvironmentVariablesFromList(
+      this,
+      webAppStackEntrepotVariables,
+      { sensitive: false },
+    )
+    const entrepotSensitiveVariables = optionalEnvironmentVariablesFromList(
+      this,
+      webAppStackEntrepotSensitiveVariables,
       { sensitive: true },
     )
 
@@ -221,6 +246,15 @@ export class WebAppStack extends TerraformStack {
         ALBERT_SERVICE_URL: environmentVariables.ALBERT_SERVICE_URL.value,
         SMTP_PORT: isMain ? smtpPort : '1025',
         DATASPACE_API_MOCK: isMain ? '0' : '1',
+        // Entrepôt SSH tunnel: bastion coordinates (optional, from MIN) + the fixed target of the
+        // entrepôt database reachable through it. The entrypoint opens the tunnel only when
+        // ENTREPOT_BASTION_HOST is set, and ENTREPOT_DATABASE_URL points at the local tunnel port.
+        ENTREPOT_BASTION_HOST: entrepotVariables.ENTREPOT_BASTION_HOST.value,
+        ENTREPOT_BASTION_USER: entrepotVariables.ENTREPOT_BASTION_USER.value,
+        ENTREPOT_BASTION_PORT: entrepotVariables.ENTREPOT_BASTION_PORT.value,
+        ENTREPOT_DB_HOST: '172.16.20.14',
+        ENTREPOT_DB_PORT: '5432',
+        ENTREPOT_TUNNEL_PORT: '5433',
       },
       secretEnvironmentVariables: {
         BREVO_API_KEY: isMain
@@ -265,6 +299,12 @@ export class WebAppStack extends TerraformStack {
           : 'maildev.coop-numerique.anct.gouv.fr',
         DATASPACE_API_KEY:
           sensitiveEnvironmentVariables.DATASPACE_API_KEY.value,
+        // Bastion private key + entrepôt connection string (postgres://…@localhost:tunnel/…).
+        // Empty until MIN provides them; the entrepôt-backed pages stay unavailable meanwhile.
+        ENTREPOT_BASTION_SSH_KEY:
+          entrepotSensitiveVariables.ENTREPOT_BASTION_SSH_KEY.value,
+        ENTREPOT_DATABASE_URL:
+          entrepotSensitiveVariables.ENTREPOT_DATABASE_URL.value,
       },
       name: containerName,
       minScale: isMain ? 2 : namespace === 'dev' ? 1 : 0,

--- a/packages/cdk/src/environmentVariable.ts
+++ b/packages/cdk/src/environmentVariable.ts
@@ -41,3 +41,35 @@ export const environmentVariablesFromList = <T extends string>(
 
   return result as { [key in T]: EnvironmentVariable }
 }
+
+export const optionalEnvironmentVariable = (
+  scope: Construct,
+  name: string,
+  { sensitive }: { sensitive: boolean },
+): EnvironmentVariable => {
+  const variable = new TerraformVariable(scope, name, {
+    type: 'string',
+    sensitive,
+    default: '',
+  }) as EnvironmentVariable
+
+  variable.overrideLogicalId(name)
+
+  return variable
+}
+
+export const optionalEnvironmentVariablesFromList = <T extends string>(
+  scope: Construct,
+  variableNames: readonly T[],
+  { sensitive }: { sensitive: boolean },
+): { [key in T]: EnvironmentVariable } => {
+  const result = {} as { [key in T]: EnvironmentVariable }
+
+  for (const variableName of variableNames) {
+    result[variableName] = optionalEnvironmentVariable(scope, variableName, {
+      sensitive,
+    })
+  }
+
+  return result as { [key in T]: EnvironmentVariable }
+}


### PR DESCRIPTION
Temporary validation page that counts admin.commune and shows the current database. Used to confirm the entrepôt schemas are reachable on ephemeral and prod environments once DATABASE_URL points at the entrepôt; gracefully reports the schema as absent otherwise.