### PR TITLE
fix(api): add id tie-breaker to cursor pagination ordering

### DIFF
--- a/apps/web/src/app/api/v1/structures/route.ts
+++ b/apps/web/src/app/api/v1/structures/route.ts
@@ -480,7 +480,7 @@ export const GET = createApiV1Route
     }
 
     const structures = await prismaClient.structure.findMany({
-      orderBy: [{ creation: 'desc' }],
+      orderBy: [{ creation: 'desc' }, { id: 'desc' }],
       take: cursorPagination.take,
       skip: cursorPagination.skip,
       where,

--- a/apps/web/src/app/api/v1/utilisateurs/route.ts
+++ b/apps/web/src/app/api/v1/utilisateurs/route.ts
@@ -520,7 +520,7 @@ export const GET = createApiV1Route
         ...conseillerNumeriqueIdPgFilter,
         ...dataspaceIdFilter,
       },
-      orderBy: [{ created: 'desc' }],
+      orderBy: [{ created: 'desc' }, { id: 'desc' }],
       take: cursorPagination.take,
       skip: cursorPagination.skip,
       cursor: validatedCursor


### PR DESCRIPTION
Structures and utilisateurs list endpoints sorted only on the creation timestamp while paginating with a composite (creation, id) cursor. Rows sharing the exact same timestamp (bulk imports) were returned in non-deterministic order, causing duplicates or skipped items across page boundaries.