### PR TITLE
fix(lieu): géocode l'adresse de la structure SIRET et rejette les correspondances communales

### DIFF
--- a/apps/web/src/external-apis/apiAdresse.ts
+++ b/apps/web/src/external-apis/apiAdresse.ts
@@ -53,6 +53,7 @@ export type SearchAdresseOptions = {
   limit?: number
   autocomplete?: boolean
   type?: AdresseType
+  citycode?: string
 }
 
 export const searchAdresses = async (
@@ -70,6 +71,7 @@ export const searchAdresses = async (
   url.searchParams.append('limit', limit.toString(10))
   url.searchParams.append('autocomplete', autocomplete ? '1' : '0')
   if (options?.type) url.searchParams.append('type', options.type)
+  if (options?.citycode) url.searchParams.append('citycode', options.citycode)
 
   const response = await fetch(url.toString())
   const body = (await response.json()) as FeatureCollection

--- a/apps/web/src/features/lieux-activite/components/informations-generales/InformationsGeneralesEditionFields.tsx
+++ b/apps/web/src/features/lieux-activite/components/informations-generales/InformationsGeneralesEditionFields.tsx
@@ -8,6 +8,10 @@ import {
   AdresseBanOptions,
 } from '@app/web/features/adresse/combo-box/AdresseBanComboBox'
 import {
+  adresseNonVerifiableMessage,
+  geocodeStructureAdresse,
+} from '@app/web/features/structures/siret/geocodeStructureAdresse'
+import {
   SiretSearchComboBox,
   SiretSearchOptions,
 } from '@app/web/features/structures/siret/SiretSearchComboBox'
@@ -16,6 +20,7 @@ import { withForm } from '@app/web/libs/form/use-app-form'
 import Button from '@codegouvfr/react-dsfr/Button'
 import Notice from '@codegouvfr/react-dsfr/Notice'
 import { useStore } from '@tanstack/react-form'
+import { useState } from 'react'
 import {
   type InformationsGeneralesFormData,
   informationsGeneralesFormOptions,
@@ -35,6 +40,9 @@ export const InformationsGeneralesEditionFields = withForm({
     const siretSearch = useStore(
       form.store,
       (state) => state.values.siretSearch,
+    )
+    const [siretSearchError, setSiretSearchError] = useState<string | null>(
+      null,
     )
 
     const protectedFieldsDisabled = hasActiveEmployees || isPending
@@ -57,7 +65,18 @@ export const InformationsGeneralesEditionFields = withForm({
           {(field) => (
             <field.ComboBox
               isPending={isPending}
-              onSelect={(item) => form.setFieldValue('nom', item.nom)}
+              onSelect={async (item) => {
+                setSiretSearchError(null)
+                form.setFieldValue('adresseBan', null)
+                const adresseBan = await geocodeStructureAdresse(item)
+                if (!adresseBan) {
+                  form.setFieldValue('siretSearch', null)
+                  setSiretSearchError(adresseNonVerifiableMessage(item))
+                  return
+                }
+                form.setFieldValue('nom', item.nom)
+                form.setFieldValue('adresseBan', adresseBan)
+              }}
               {...SiretSearchComboBox}
             >
               {({
@@ -127,6 +146,12 @@ export const InformationsGeneralesEditionFields = withForm({
             </field.ComboBox>
           )}
         </form.AppField>
+
+        {!noSiret && siretSearchError && (
+          <p className="fr-text-default--error fr-text--sm">
+            {siretSearchError}
+          </p>
+        )}
 
         {!hasActiveEmployees && (
           <>

--- a/apps/web/src/features/lieux-activite/components/informations-generales/informationsGeneralesFormData.ts
+++ b/apps/web/src/features/lieux-activite/components/informations-generales/informationsGeneralesFormData.ts
@@ -27,6 +27,14 @@ export const InformationsGeneralesFormValidation = z
         message: 'Veuillez rechercher et sélectionner une structure',
       })
     }
+    if (!data.noSiret && data.siretSearch && !data.adresseBan) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['siretSearch'],
+        message:
+          'L’adresse de la structure n’a pas pu être déterminée, veuillez sélectionner à nouveau la structure',
+      })
+    }
     if (data.noSiret && !data.nom?.trim()) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,

--- a/apps/web/src/features/structures/siret/geocodeStructureAdresse.ts
+++ b/apps/web/src/features/structures/siret/geocodeStructureAdresse.ts
@@ -1,0 +1,34 @@
+import { type Feature, searchAdresses } from '@app/web/external-apis/apiAdresse'
+import type { AdresseBanData } from '@app/web/external-apis/ban/AdresseBanValidation'
+import { banFeatureToAdresseBanData } from '@app/web/external-apis/ban/banFeatureToAdresseBanData'
+import type { StructureSearchResult } from '@app/web/features/inscription/use-cases/renseigner-structure-employeuse/searchStructureEmployeuseCombined'
+
+export const adresseNonVerifiableMessage = ({
+  adresse,
+  codePostal,
+  commune,
+}: StructureSearchResult): string =>
+  `L’adresse « ${adresse} ${codePostal} ${commune} » de cet établissement est introuvable dans la Base Adresse Nationale. Contactez le support pour ajouter ce lieu.`
+
+// Un résultat de type « municipality » est un repli sur le centre de la
+// commune : la voie n’a pas été trouvée, on le considère comme un échec.
+const isPreciseMatchIn =
+  (codeInsee: string) =>
+  ({ properties }: Feature): boolean =>
+    properties.citycode === codeInsee && properties.type !== 'municipality'
+
+export const geocodeStructureAdresse = async (
+  structure: StructureSearchResult,
+): Promise<AdresseBanData | null> => {
+  if (!structure.codeInsee) return null
+
+  const banFeatures = await searchAdresses(
+    `${structure.adresse} ${structure.codePostal} ${structure.commune}`,
+    { limit: 1, autocomplete: false, citycode: structure.codeInsee },
+  )
+  const banFeature = banFeatures
+    .filter(isPreciseMatchIn(structure.codeInsee))
+    .at(0)
+
+  return banFeature ? banFeatureToAdresseBanData(banFeature) : null
+}


### PR DESCRIPTION
Lors de la sélection d'une structure par SIRET, l'adresse est désormais géocodée dans la Base Adresse Nationale en filtrant sur le code INSEE. Les correspondances de type « municipality » (repli sur le centre de la commune) sont rejetées, et la sélection est invalidée avec un message si l'adresse reste introuvable.