### PR TITLE
feat(maintenance): mode maintenance activable depuis l'admin

### DIFF
--- a/apps/web/prisma/migrations/20260612115420_add_maintenances/migration.sql
+++ b/apps/web/prisma/migrations/20260612115420_add_maintenances/migration.sql
@@ -1,0 +1,13 @@
+-- CreateTable
+CREATE TABLE "coop"."maintenances" (
+    "id" UUID NOT NULL,
+    "started_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "ended_at" TIMESTAMP(3),
+    "message" TEXT,
+    "created_by" UUID,
+
+    CONSTRAINT "maintenances_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "maintenances_ended_at_idx" ON "coop"."maintenances"("ended_at");

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -96,6 +96,21 @@ enum OnboardingStatus {
   @@schema("coop")
 }
 
+// Maintenance : une ligne par maintenance. `endedAt` nul = maintenance en cours
+// (écritures des médiateurs/coordinateurs bloquées, message affiché). Renseigner
+// `endedAt` clôt la maintenance, ce qui conserve l’historique de toutes les maintenances.
+model Maintenance {
+  id        String    @id @default(uuid()) @db.Uuid
+  startedAt DateTime  @default(now()) @map("started_at")
+  endedAt   DateTime? @map("ended_at")
+  message   String?
+  createdBy String?   @map("created_by") @db.Uuid
+
+  @@index([endedAt])
+  @@map("maintenances")
+  @@schema("coop")
+}
+
 model User {
   id                String            @id @default(uuid()) @db.Uuid
   firstName         String?           @map("first_name")

--- a/apps/web/src/app/administration/outils/page.tsx
+++ b/apps/web/src/app/administration/outils/page.tsx
@@ -2,6 +2,7 @@ import CoopPageContainer from '@app/web/app/coop/CoopPageContainer'
 import { metadataTitle } from '@app/web/app/metadataTitle'
 import Card from '@app/web/components/Card'
 import SkipLinksPortal from '@app/web/components/SkipLinksPortal'
+import MaintenanceMode from '@app/web/features/maintenance-mode/use-cases/administration/MaintenanceMode'
 import NouveauReminders from '@app/web/features/utilisateurs/use-cases/nouveau-reminders/components/NouveauReminders'
 import SignupReminders from '@app/web/features/utilisateurs/use-cases/signup-reminders/components/SignupReminders'
 import AdministrationBreadcrumbs from '@app/web/libs/ui/administration/AdministrationBreadcrumbs'
@@ -27,6 +28,11 @@ const Page = () => {
         </AdministrationTitle>
         <div className="fr-container fr-my-8w">
           <div className="fr-grid-row fr-grid-row--gutters">
+            <div className="fr-col-12">
+              <Card title="Mode maintenance">
+                <MaintenanceMode />
+              </Card>
+            </div>
             <div className="fr-col-12">
               <Card title="Export des accompagnements">
                 <DatePickerDownload />

--- a/apps/web/src/app/coop/layout.tsx
+++ b/apps/web/src/app/coop/layout.tsx
@@ -2,6 +2,7 @@ import PublicFooter from '@app/web/app/(public)/PublicFooter'
 import { authenticateUser } from '@app/web/auth/authenticateUser'
 import Header from '@app/web/components/Header'
 import InscriptionStepsLayout from '@app/web/features/inscription/components/InscriptionStepsLayout'
+import { MaintenanceModeBanner } from '@app/web/features/maintenance-mode/components/MaintenanceModeBanner'
 import Link from 'next/link'
 import { redirect } from 'next/navigation'
 import React, { PropsWithChildren } from 'react'
@@ -49,6 +50,7 @@ const Layout = async ({ children }: PropsWithChildren) => {
   return (
     <div className="fr-layout">
       <div id="skip-links" />
+      <MaintenanceModeBanner />
       {children}
     </div>
   )

--- a/apps/web/src/features/maintenance-mode/components/MaintenanceModeBanner.tsx
+++ b/apps/web/src/features/maintenance-mode/components/MaintenanceModeBanner.tsx
@@ -1,0 +1,20 @@
+import { getMaintenanceMode } from '@app/web/features/maintenance-mode/db/getMaintenanceMode'
+import Notice from '@codegouvfr/react-dsfr/Notice'
+
+export const MaintenanceModeBanner = async () => {
+  const { active, message } = await getMaintenanceMode()
+
+  if (!active) {
+    return null
+  }
+
+  return (
+    <div style={{ position: 'sticky', top: 0, zIndex: 1000 }}>
+      <Notice
+        isClosable={false}
+        className="fr-notice--alert fr-notice--flex fr-align-items-center"
+        title={<span style={{ whiteSpace: 'pre-line' }}>{message}</span>}
+      />
+    </div>
+  )
+}

--- a/apps/web/src/features/maintenance-mode/db/getMaintenanceMode.ts
+++ b/apps/web/src/features/maintenance-mode/db/getMaintenanceMode.ts
@@ -1,0 +1,41 @@
+import { defaultMaintenanceMessage } from '@app/web/features/maintenance-mode/domain/maintenanceMessage'
+import { prismaClient } from '@app/web/prismaClient'
+
+export type MaintenanceModeState = {
+  active: boolean
+  message: string
+}
+
+export type MaintenanceHistoryEntry = {
+  id: string
+  startedAt: Date
+  endedAt: Date | null
+  message: string | null
+}
+
+// La maintenance en cours est l’unique période non close (endedAt nul).
+const currentMaintenance = () =>
+  prismaClient.maintenance.findFirst({
+    where: { endedAt: null },
+    orderBy: { startedAt: 'desc' },
+  })
+
+export const getMaintenanceMode = async (): Promise<MaintenanceModeState> => {
+  const current = await currentMaintenance()
+
+  return {
+    active: current != null,
+    message: current?.message ?? defaultMaintenanceMessage,
+  }
+}
+
+export const getMaintenanceHistory = async (
+  take = 20,
+): Promise<MaintenanceHistoryEntry[]> =>
+  prismaClient.maintenance.findMany({
+    select: { id: true, startedAt: true, endedAt: true, message: true },
+    orderBy: { startedAt: 'desc' },
+    take,
+  })
+
+export { currentMaintenance }

--- a/apps/web/src/features/maintenance-mode/db/setMaintenanceMode.ts
+++ b/apps/web/src/features/maintenance-mode/db/setMaintenanceMode.ts
@@ -1,0 +1,43 @@
+import {
+  currentMaintenance,
+  getMaintenanceMode,
+  type MaintenanceModeState,
+} from '@app/web/features/maintenance-mode/db/getMaintenanceMode'
+import { prismaClient } from '@app/web/prismaClient'
+
+// Activer ouvre une nouvelle période (ou met à jour le message de la période en cours).
+// Désactiver clôt la période en cours en renseignant `endedAt`, ce qui l’archive.
+export const setMaintenanceMode = async ({
+  active,
+  message,
+  updatedBy,
+}: {
+  active: boolean
+  message: string | null
+  updatedBy: string
+}): Promise<MaintenanceModeState> => {
+  const current = await currentMaintenance()
+
+  if (!active) {
+    if (current) {
+      await prismaClient.maintenance.update({
+        where: { id: current.id },
+        data: { endedAt: new Date() },
+      })
+    }
+    return getMaintenanceMode()
+  }
+
+  if (current) {
+    await prismaClient.maintenance.update({
+      where: { id: current.id },
+      data: { message },
+    })
+    return getMaintenanceMode()
+  }
+
+  await prismaClient.maintenance.create({
+    data: { message, createdBy: updatedBy },
+  })
+  return getMaintenanceMode()
+}

--- a/apps/web/src/features/maintenance-mode/domain/canMutateDuringMaintenance.spec.ts
+++ b/apps/web/src/features/maintenance-mode/domain/canMutateDuringMaintenance.spec.ts
@@ -1,0 +1,30 @@
+import { canMutateDuringMaintenance } from '@app/web/features/maintenance-mode/domain/canMutateDuringMaintenance'
+
+describe('canMutateDuringMaintenance', () => {
+  it('autorise toutes les écritures hors maintenance', () => {
+    expect(canMutateDuringMaintenance({ role: 'User', active: false })).toBe(
+      true,
+    )
+    expect(canMutateDuringMaintenance({ role: 'Admin', active: false })).toBe(
+      true,
+    )
+    expect(canMutateDuringMaintenance({ role: 'Support', active: false })).toBe(
+      true,
+    )
+  })
+
+  it('bloque les médiateurs/coordinateurs (role User) pendant la maintenance', () => {
+    expect(canMutateDuringMaintenance({ role: 'User', active: true })).toBe(
+      false,
+    )
+  })
+
+  it('laisse passer les admins et le support pendant la maintenance', () => {
+    expect(canMutateDuringMaintenance({ role: 'Admin', active: true })).toBe(
+      true,
+    )
+    expect(canMutateDuringMaintenance({ role: 'Support', active: true })).toBe(
+      true,
+    )
+  })
+})

--- a/apps/web/src/features/maintenance-mode/domain/canMutateDuringMaintenance.ts
+++ b/apps/web/src/features/maintenance-mode/domain/canMutateDuringMaintenance.ts
@@ -1,0 +1,11 @@
+import type { UserRole } from '@prisma/client'
+
+// Pendant une maintenance, seuls les médiateurs/coordinateurs (role `User`) sont bloqués.
+// Les administrateurs et le support conservent leur accès en écriture.
+export const canMutateDuringMaintenance = ({
+  role,
+  active,
+}: {
+  role: UserRole
+  active: boolean
+}): boolean => !active || role !== 'User'

--- a/apps/web/src/features/maintenance-mode/domain/maintenanceMessage.ts
+++ b/apps/web/src/features/maintenance-mode/domain/maintenanceMessage.ts
@@ -1,0 +1,2 @@
+export const defaultMaintenanceMessage = `Une opération de maintenance est en cours.
+Les modifications sont temporairement désactivées, vous pouvez toujours consulter vos données.`

--- a/apps/web/src/features/maintenance-mode/use-cases/administration/MaintenanceMode.tsx
+++ b/apps/web/src/features/maintenance-mode/use-cases/administration/MaintenanceMode.tsx
@@ -1,0 +1,115 @@
+'use client'
+
+import { createToast } from '@app/ui/toast/createToast'
+import { withTrpc } from '@app/web/components/trpc/withTrpc'
+import { defaultMaintenanceMessage } from '@app/web/features/maintenance-mode/domain/maintenanceMessage'
+import { trpc } from '@app/web/trpc'
+import Button from '@codegouvfr/react-dsfr/Button'
+import Input from '@codegouvfr/react-dsfr/Input'
+import ToggleSwitch from '@codegouvfr/react-dsfr/ToggleSwitch'
+import { useState } from 'react'
+
+const dateFormat = new Intl.DateTimeFormat('fr-FR', {
+  dateStyle: 'short',
+  timeStyle: 'short',
+})
+
+const MaintenanceMode = () => {
+  const status = trpc.maintenance.status.useQuery()
+  const history = trpc.maintenance.history.useQuery()
+  const mutation = trpc.maintenance.set.useMutation()
+
+  // `null` => non édité, on affiche la valeur serveur ; sinon la saisie de l’admin.
+  const [editedMessage, setEditedMessage] = useState<string | null>(null)
+
+  const active = status.data?.active ?? false
+  const message = editedMessage ?? status.data?.message ?? ''
+  const pending = mutation.isPending || status.isLoading
+
+  const apply = async (nextActive: boolean) => {
+    try {
+      const result = await mutation.mutateAsync({
+        active: nextActive,
+        message: message.trim() === '' ? null : message,
+      })
+      await Promise.all([status.refetch(), history.refetch()])
+      setEditedMessage(null)
+
+      createToast({
+        priority: 'success',
+        message: result.active
+          ? 'Mode maintenance activé'
+          : 'Mode maintenance désactivé',
+      })
+    } catch {
+      createToast({
+        priority: 'error',
+        message: 'Échec de la mise à jour du mode maintenance',
+      })
+    }
+  }
+
+  return (
+    <div className="fr-flex fr-direction-column fr-flex-gap-4v">
+      <p className="fr-text--sm fr-mb-0">
+        Lorsque le mode maintenance est activé, les médiateurs et coordinateurs
+        ne peuvent plus modifier leurs données (la consultation reste possible).
+        Les administrateurs et le support conservent leur accès. Chaque
+        maintenance est enregistrée dans l’historique ci-dessous.
+      </p>
+      <Input
+        textArea
+        label="Message affiché aux utilisateurs"
+        hintText="Laissez vide pour utiliser le message par défaut."
+        nativeTextAreaProps={{
+          value: message,
+          onChange: (event) => setEditedMessage(event.target.value),
+          rows: 3,
+          placeholder: defaultMaintenanceMessage,
+          disabled: pending,
+        }}
+      />
+      <div className="fr-flex fr-flex-gap-4v fr-align-items-center">
+        <ToggleSwitch
+          label={
+            active ? 'Mode maintenance activé' : 'Mode maintenance désactivé'
+          }
+          checked={active}
+          showCheckedHint={false}
+          disabled={pending}
+          onChange={(checked) => apply(checked)}
+        />
+        {active && (
+          <Button
+            type="button"
+            priority="secondary"
+            size="small"
+            disabled={pending}
+            onClick={() => apply(true)}
+          >
+            Mettre à jour le message
+          </Button>
+        )}
+      </div>
+      {history.data && history.data.length > 0 && (
+        <div>
+          <h4 className="fr-h6 fr-mb-1v">Historique des maintenances</h4>
+          <ul className="fr-text--sm fr-mb-0">
+            {history.data.map((entry) => (
+              <li key={entry.id}>
+                {dateFormat.format(new Date(entry.startedAt))}
+                {' → '}
+                {entry.endedAt
+                  ? dateFormat.format(new Date(entry.endedAt))
+                  : 'EN COURS'}
+                {entry.message ? ` : ${entry.message}` : ''}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default withTrpc(MaintenanceMode)

--- a/apps/web/src/features/maintenance-mode/use-cases/administration/MaintenanceModeValidation.ts
+++ b/apps/web/src/features/maintenance-mode/use-cases/administration/MaintenanceModeValidation.ts
@@ -1,0 +1,8 @@
+import { z } from 'zod'
+
+export const MaintenanceModeValidation = z.object({
+  active: z.boolean(),
+  message: z.string().trim().min(1).max(500).nullish(),
+})
+
+export type MaintenanceModeData = z.infer<typeof MaintenanceModeValidation>

--- a/apps/web/src/features/maintenance-mode/use-cases/administration/maintenanceRouter.ts
+++ b/apps/web/src/features/maintenance-mode/use-cases/administration/maintenanceRouter.ts
@@ -1,0 +1,28 @@
+import {
+  getMaintenanceHistory,
+  getMaintenanceMode,
+} from '@app/web/features/maintenance-mode/db/getMaintenanceMode'
+import { setMaintenanceMode } from '@app/web/features/maintenance-mode/db/setMaintenanceMode'
+import { MaintenanceModeValidation } from '@app/web/features/maintenance-mode/use-cases/administration/MaintenanceModeValidation'
+import { protectedProcedure, router } from '@app/web/server/rpc/createRouter'
+import { enforceIsAdmin } from '@app/web/server/rpc/enforceIsAdmin'
+
+export const maintenanceRouter = router({
+  status: protectedProcedure.query(() => getMaintenanceMode()),
+  history: protectedProcedure.query(({ ctx: { user } }) => {
+    enforceIsAdmin(user)
+
+    return getMaintenanceHistory()
+  }),
+  set: protectedProcedure
+    .input(MaintenanceModeValidation)
+    .mutation(({ input: { active, message }, ctx: { user } }) => {
+      enforceIsAdmin(user)
+
+      return setMaintenanceMode({
+        active,
+        message: message ?? null,
+        updatedBy: user.id,
+      })
+    }),
+})

--- a/apps/web/src/server/rpc/appRouter.ts
+++ b/apps/web/src/server/rpc/appRouter.ts
@@ -1,5 +1,6 @@
 import { tagsRouter } from '@app/web/features/activites/use-cases/tags/tagsRouter'
 import { dataspaceAdminRouter } from '@app/web/features/dataspace/use-cases/administration/dataspaceAdminRouter'
+import { maintenanceRouter } from '@app/web/features/maintenance-mode/use-cases/administration/maintenanceRouter'
 import { apiClientRouter } from '@app/web/server/rpc/apiClient/apiClientRouter'
 import { beneficiairesRouter } from '@app/web/server/rpc/beneficiaires/beneficiairesRouter'
 import { craRouter } from '@app/web/server/rpc/cra/craRouter'
@@ -33,6 +34,7 @@ export const appRouter = router({
   employeStructure: employeStructureRouter,
   tags: tagsRouter,
   dataspaceAdmin: dataspaceAdminRouter,
+  maintenance: maintenanceRouter,
 })
 // export type definition of API
 export type AppRouter = typeof appRouter

--- a/apps/web/src/server/rpc/createRouter.ts
+++ b/apps/web/src/server/rpc/createRouter.ts
@@ -1,3 +1,5 @@
+import { getMaintenanceMode } from '@app/web/features/maintenance-mode/db/getMaintenanceMode'
+import { canMutateDuringMaintenance } from '@app/web/features/maintenance-mode/domain/canMutateDuringMaintenance'
 import { AppContext } from '@app/web/server/rpc/createContext'
 import { transformer } from '@app/web/utils/serialization'
 import { initTRPC, TRPCError } from '@trpc/server'
@@ -58,6 +60,28 @@ const isActive = middleware(({ ctx, next }) => {
 })
 
 /**
+ * Reusable middleware to block writes during maintenance mode.
+ * Only mutations are intercepted (reads stay available). Admins and support
+ * keep their access ; standard users (médiateurs/coordinateurs) are blocked.
+ */
+const enforceMaintenanceMode = middleware(async ({ ctx, next, type }) => {
+  if (type !== 'mutation' || !ctx.user) {
+    return next()
+  }
+
+  const { active, message } = await getMaintenanceMode()
+
+  if (!canMutateDuringMaintenance({ role: ctx.user.role, active })) {
+    throw new TRPCError({ code: 'FORBIDDEN', message })
+  }
+
+  return next()
+})
+
+/**
  * Protected procedure
  * */
-export const protectedProcedure = procedure.use(isAuthenticated).use(isActive)
+export const protectedProcedure = procedure
+  .use(isAuthenticated)
+  .use(isActive)
+  .use(enforceMaintenanceMode)


### PR DESCRIPTION
Permet de bloquer les écritures des médiateurs/coordinateurs pendant des opérations de maintenance lourdes, tout en laissant la consultation ouverte.

- table `maintenances` (période début/fin) + migration : « en maintenance » = il existe une période non close, ce qui conserve l'historique
- garde centralisée : middleware sur protectedProcedure bloquant les mutations pour le role User ; admins et support conservent l'accès
- /administration/outils : interrupteur, message éditable et historique
- bandeau d'avertissement dans l'espace coop quand la maintenance est active