### PR TITLE
chore(prisma): isole la table _prisma_migrations dans le schéma coop

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -412,7 +412,7 @@ jobs:
       - run:
           name: 'Create CI database schema'
           command: |
-            pnpm --silent -F @app/web prisma migrate deploy
+            pnpm --silent -F @app/web db:migrate-deploy
       - run:
           name: Isolate built standalone application to correctly e2e test node_modules bundling and run
           background: true
@@ -459,7 +459,7 @@ jobs:
       - run:
           name: 'Create CI database schema'
           command: |
-            pnpm --silent -F @app/web prisma migrate deploy
+            pnpm --silent -F @app/web db:migrate-deploy
       - run:
           name: 'Load fixtures'
           command: |
@@ -555,7 +555,7 @@ jobs:
       - run:
           name: 'Migrate database'
           command: |
-            pnpm --silent -F @app/web prisma migrate deploy
+            pnpm --silent -F @app/web db:migrate-deploy
       - run:
           name: Set deployment status to data loading
           command: pnpm --silent cli github:deployment:update $DEPLOYMENT_ID in_progress -d 'Loading data' -l https://app.circleci.com/pipelines/workflows/$CIRCLE_WORKFLOW_ID

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -22,6 +22,7 @@
     "with-env": "dotenv -e ../../.env --",
     "with-remote-env": "dotenv -e ../../.env.remote -e ../../.env --",
     "prisma": "pnpm --silent with-env prisma",
+    "db:migrate-deploy": "pnpm --silent prisma migrate deploy && pnpm --silent prisma db execute --schema ./prisma/schema.prisma --file ./prisma/sql/move-prisma-migrations-to-coop.sql",
     "erd": "pnpm erd:md && pnpm erd:svg && pnpm erd:pdf",
     "erd:md": "DISABLE_ERD= pnpm prisma generate",
     "erd:svg": "mmdc -i prisma/ERD.md -o prisma/ERD.svg && mv prisma/ERD-1.svg prisma/ERD.svg",

--- a/apps/web/prisma/sql/move-prisma-migrations-to-coop.sql
+++ b/apps/web/prisma/sql/move-prisma-migrations-to-coop.sql
@@ -1,0 +1,22 @@
+-- Move Prisma's migration-tracking table into the `coop` schema.
+--
+-- Coop and the MIN/Dataspace entrepôt both run Prisma, so both own a
+-- `public._prisma_migrations` table. Prisma hardcodes that name and forbids
+-- renaming it (prisma/prisma#18625, #14806), so once the two databases are
+-- merged the tables would collide. Isolating Coop's history in `coop`
+-- (`coop._prisma_migrations`) lets MIN keep `public._prisma_migrations`.
+--
+-- This runs out-of-band, AFTER `prisma migrate deploy` (never inside a
+-- migration), so the migration engine never holds a cached `public` reference
+-- while the table moves. Prisma resolves the relocated table through the
+-- connection search_path (`coop,public`) — validated with `migrate status`.
+--
+-- Idempotent: only acts while the table is still in `public` and `coop`
+-- exists, so it is a no-op on every run after the one-time move.
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_tables WHERE schemaname = 'public' AND tablename = '_prisma_migrations')
+     AND EXISTS (SELECT 1 FROM pg_namespace WHERE nspname = 'coop') THEN
+    ALTER TABLE public._prisma_migrations SET SCHEMA coop;
+  END IF;
+END $$;

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "start:web": "pnpm -F web dev",
     "fixtures:load": "pnpm -F fixtures load",
     "prisma:generate-migration": "pnpm --silent -F @app/web prisma migrate dev --name",
-    "db:init": "pnpm -F web prisma generate && pnpm -F web prisma migrate deploy",
+    "db:init": "pnpm -F web prisma generate && pnpm -F web db:migrate-deploy",
     "docker:start": "docker compose -f ./docker-compose.dev.yml -p coop up -d",
     "docker:stop": "docker compose -f ./docker-compose.dev.yml -p coop down",
     "docker:reset": "pnpm docker:stop && docker volume rm coop_pgdata && pnpm docker:start && pnpm db:init",


### PR DESCRIPTION
Coop et l'entrepôt MIN/Dataspace utilisent tous deux Prisma et possèdent donc chacun une table public._prisma_migrations. Prisma fige ce nom et interdit de le renommer (prisma#18625, #14806) : à la fusion des bases, les deux tables entreraient en collision.

Un script SQL idempotent, exécuté après chaque migrate deploy via le nouveau script db:migrate-deploy, déplace la table dans coop tant qu'elle est encore dans public. Hors du moteur Prisma (pas de référence public mise en cache pendant une migration) ; Prisma la résout ensuite via le search_path coop,public (validé avec migrate status).

Branché sur db:init (local) et les 3 étapes migrate deploy de la CI (éphémère, dev, prod).