### PR TITLE
fix(structures): normalise le code_insee via BAN pour éviter les doublons à la sync

### DIFF
--- a/apps/web/src/features/structures/findOrCreateStructure.spec.ts
+++ b/apps/web/src/features/structures/findOrCreateStructure.spec.ts
@@ -1,0 +1,203 @@
+import type { Feature } from '@app/web/external-apis/apiAdresse'
+import { searchAdresse } from '@app/web/external-apis/apiAdresse'
+import { prismaClient } from '@app/web/prismaClient'
+import { findOrCreateStructure } from './findOrCreateStructure'
+
+jest.mock('@app/web/external-apis/apiAdresse', () => ({
+  searchAdresse: jest.fn(),
+}))
+
+jest.mock('@app/web/prismaClient', () => ({
+  prismaClient: {
+    structure: {
+      findFirst: jest.fn(),
+      findMany: jest.fn(),
+      create: jest.fn(),
+      update: jest.fn(),
+    },
+    structureCartographieNationale: {
+      findFirst: jest.fn(),
+    },
+  },
+}))
+
+const mockedSearchAdresse = searchAdresse as jest.MockedFunction<
+  typeof searchAdresse
+>
+const structure = prismaClient.structure as unknown as {
+  findFirst: jest.Mock
+  findMany: jest.Mock
+  create: jest.Mock
+  update: jest.Mock
+}
+const cartographie = prismaClient.structureCartographieNationale as unknown as {
+  findFirst: jest.Mock
+}
+
+// BAN feature whose citycode (codeInsee) is the geocoded, canonical value.
+const featureWithCitycode = (citycode: string): Feature => ({
+  type: 'Feature',
+  geometry: { type: 'Point', coordinates: [-0.77, 48.07] },
+  properties: {
+    label: '1 Place du Général de Gaulle 53000 Laval',
+    score: 0.9,
+    housenumber: '1',
+    id: `${citycode}_xxxx_00001`,
+    type: 'housenumber',
+    name: '1 Place du Général de Gaulle',
+    postcode: '53000',
+    citycode,
+    x: 0,
+    y: 0,
+    city: 'Laval',
+    context: '53, Mayenne, Pays de la Loire',
+    importance: 0.5,
+    street: 'Place du Général de Gaulle',
+  },
+})
+
+const mayenne = {
+  siret: '22530001100015',
+  nom: 'DEPARTEMENT DE LA MAYENNE',
+  adresse: '1 Place du Général de Gaulle',
+  codePostal: '53000',
+  commune: 'LAVAL',
+}
+
+describe('findOrCreateStructure', () => {
+  beforeEach(() => {
+    mockedSearchAdresse.mockReset()
+    structure.findFirst.mockReset().mockResolvedValue(null)
+    structure.findMany.mockReset().mockResolvedValue([])
+    structure.create.mockReset().mockResolvedValue({ id: 'created-id' })
+    structure.update.mockReset().mockResolvedValue(undefined)
+    cartographie.findFirst.mockReset().mockResolvedValue(null)
+  })
+
+  test('matches an existing structure when the payload codeInsee diverges from the geocoded one', async () => {
+    // Payload carries the siège codeInsee (53130); BAN resolves the real one (53000).
+    mockedSearchAdresse.mockResolvedValue(featureWithCitycode('53000'))
+    structure.findFirst.mockResolvedValueOnce({
+      id: 'existing-mayenne',
+      suppression: null,
+    })
+
+    const result = await findOrCreateStructure({
+      ...mayenne,
+      codeInsee: '53130',
+    })
+
+    expect(result.id).toBe('existing-mayenne')
+    // The lookup must use the resolved (geocoded) codeInsee, not the payload one.
+    expect(structure.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          siret: mayenne.siret,
+          codeInsee: '53000',
+          suppression: null,
+        }),
+      }),
+    )
+    expect(structure.create).not.toHaveBeenCalled()
+  })
+
+  test('creates from the geocoded address (single BAN call) when nothing matches', async () => {
+    mockedSearchAdresse.mockResolvedValue(featureWithCitycode('53000'))
+
+    await findOrCreateStructure({ ...mayenne, codeInsee: '53130' })
+
+    expect(mockedSearchAdresse).toHaveBeenCalledTimes(1)
+    expect(structure.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          codeInsee: '53000',
+          latitude: 48.07,
+          longitude: -0.77,
+        }),
+      }),
+    )
+  })
+
+  test('falls back to the raw codeInsee when geocoding returns nothing', async () => {
+    mockedSearchAdresse.mockResolvedValue(null)
+
+    await findOrCreateStructure({ ...mayenne, codeInsee: '53130' })
+
+    expect(structure.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ codeInsee: '53130' }),
+      }),
+    )
+  })
+
+  test('ignores a geocoding that lands in a different département (DOM mis-geocoding)', async () => {
+    // A Martinique (972xx) address mis-geocoded by BAN to Gironde (33xxx).
+    mockedSearchAdresse.mockResolvedValue(featureWithCitycode('33324'))
+
+    await findOrCreateStructure({
+      siret: '24972005300084',
+      nom: 'Communaute Agglomeration Espace Sud',
+      adresse: 'Rue case',
+      codePostal: '97228',
+      commune: 'Sainte-Luce',
+      codeInsee: '97221',
+    })
+
+    // Lookup keeps the raw payload codeInsee, not the mis-geocoded one.
+    expect(structure.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ codeInsee: '97221' }),
+      }),
+    )
+    // Create stores the raw codeInsee (not the Gironde one) and no BAN coords.
+    expect(structure.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ codeInsee: '97221' }),
+      }),
+    )
+    const createArg = structure.create.mock.calls[0][0]
+    expect(createArg.data).not.toHaveProperty('latitude')
+  })
+
+  test('short-circuits on coopId without geocoding', async () => {
+    structure.findFirst.mockResolvedValueOnce({
+      id: 'coop-id',
+      suppression: null,
+    })
+
+    const result = await findOrCreateStructure({
+      ...mayenne,
+      coopId: 'coop-id',
+      codeInsee: '53130',
+    })
+
+    expect(result.id).toBe('coop-id')
+    expect(mockedSearchAdresse).not.toHaveBeenCalled()
+    expect(structure.create).not.toHaveBeenCalled()
+  })
+
+  test('matches by nom + resolved codeInsee when there is no SIRET', async () => {
+    mockedSearchAdresse.mockResolvedValue(featureWithCitycode('53000'))
+    structure.findFirst.mockResolvedValueOnce({
+      id: 'existing-by-nom',
+      suppression: null,
+    })
+
+    const result = await findOrCreateStructure({
+      ...mayenne,
+      siret: null,
+      codeInsee: '53130',
+    })
+
+    expect(result.id).toBe('existing-by-nom')
+    expect(structure.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          nom: mayenne.nom,
+          codeInsee: '53000',
+        }),
+      }),
+    )
+    expect(structure.create).not.toHaveBeenCalled()
+  })
+})

--- a/apps/web/src/features/structures/findOrCreateStructure.ts
+++ b/apps/web/src/features/structures/findOrCreateStructure.ts
@@ -82,6 +82,19 @@ const hasAsymmetricServiceKeyword = (a: string, b: string): boolean => {
   return false
 }
 
+// Département prefix: 3 chars for overseas (97x/98x), 2 otherwise.
+const departementOf = (codeInsee: string): string =>
+  codeInsee.startsWith('97') || codeInsee.startsWith('98')
+    ? codeInsee.slice(0, 3)
+    : codeInsee.slice(0, 2)
+
+// The geocoded codeInsee is only trusted when it stays in the same département
+// as the payload. Guards against BAN mis-geocoding overseas (DOM) addresses to
+// mainland France (e.g. a Martinique 972xx address resolved to a Gironde 33xxx
+// codeInsee), which would otherwise corrupt the stored codeInsee.
+const sameDepartement = (a: string, b: string): boolean =>
+  departementOf(a) === departementOf(b)
+
 const isContainedName = (a: string, b: string): boolean => {
   const na = normalizeNom(a)
   const nb = normalizeNom(b)
@@ -173,10 +186,12 @@ const undeleteStructureIfDeleted = async ({
 /**
  * Generic helper to find or create a structure following this hierarchy:
  * 1. Find existing Structure by coopId (surest match)
- * 2. Find existing Structure by SIRET + codeInsee
- * 3. Find StructureCartographieNationale by pivot (SIRET) → create Structure from it
- * 4. Find existing Structure by nom + codeInsee (if no SIRET)
- * 5. Fallback: Geocode via searchAdresse (BAN API) and create
+ * 2. Geocode the address once (BAN) to resolve a canonical codeInsee used by
+ *    every lookup below AND by the final create (kept symmetric on purpose)
+ * 3. Find existing Structure by SIRET + resolved codeInsee
+ * 4. Find StructureCartographieNationale by pivot (SIRET) → create Structure from it
+ * 5. Find existing Structure by nom + resolved codeInsee (if no SIRET)
+ * 6. Fallback: create from the geocoded address (or raw fields if geocoding failed)
  *
  * This is reusable for both V1 imports and Dataspace imports.
  */
@@ -210,12 +225,29 @@ export const findOrCreateStructure = async ({
     }
   }
 
+  // Normalize codeInsee via BAN so lookups use the same value stored on
+  // creation. The Dataspace payload sometimes carries a codeInsee variant
+  // (siège vs antenne) that diverges from the geocoded one, which made the
+  // exact (siret, codeInsee) lookup miss an existing active structure and
+  // recreate a duplicate. Geocode once here and reuse it for the final create.
+  const fullAdresse = `${adresse}, ${codePostal} ${commune}`
+  const adresseResult = await searchAdresse(fullAdresse)
+  const banData = adresseResult
+    ? banFeatureToAdresseBanData(adresseResult)
+    : null
+  // Only trust the geocoding when it stays in the payload's département,
+  // otherwise treat it as if nothing was geocoded (lookup and create fall back
+  // to the raw payload codeInsee).
+  const trustedBanData =
+    banData && sameDepartement(banData.codeInsee, codeInsee) ? banData : null
+  const resolvedCodeInsee = trustedBanData?.codeInsee ?? codeInsee
+
   // Step 1: Find existing Structure by SIRET + codeInsee
   if (siret) {
     const existingStructure = await prismaClient.structure.findFirst({
       where: {
         siret,
-        codeInsee,
+        codeInsee: resolvedCodeInsee,
         suppression: null,
       },
       select: {
@@ -247,13 +279,17 @@ export const findOrCreateStructure = async ({
       await prismaClient.structureCartographieNationale.findFirst({
         where: {
           pivot: siret,
-          codeInsee,
+          codeInsee: resolvedCodeInsee,
         },
       })
 
     if (cartoStructure) {
       // Guard: re-check before creating to prevent duplicates
-      const existing = await findExistingBySiretOrNom({ siret, nom, codeInsee })
+      const existing = await findExistingBySiretOrNom({
+        siret,
+        nom,
+        codeInsee: resolvedCodeInsee,
+      })
       if (existing) return existing
 
       // Create structure from cartographie nationale data (has coordinates)
@@ -282,7 +318,7 @@ export const findOrCreateStructure = async ({
     const existingByNom = await prismaClient.structure.findFirst({
       where: {
         nom,
-        codeInsee,
+        codeInsee: resolvedCodeInsee,
       },
       select: {
         id: true,
@@ -307,32 +343,27 @@ export const findOrCreateStructure = async ({
     }
   }
 
-  // Step 4: Fallback - geocode via BAN API and create
+  // Step 4: Fallback - reuse the geocoded address (already fetched) and create
   // Guard: re-check before creating to prevent duplicates
   const existingGuard = await findExistingBySiretOrNom({
     siret,
     nom,
-    codeInsee,
+    codeInsee: resolvedCodeInsee,
   })
   if (existingGuard) return existingGuard
 
-  const fullAdresse = `${adresse}, ${codePostal} ${commune}`
-  const adresseResult = await searchAdresse(fullAdresse)
-
-  if (adresseResult) {
-    const banData = banFeatureToAdresseBanData(adresseResult)
-
+  if (trustedBanData) {
     return prismaClient.structure.create({
       data: {
         id: v4(),
         siret,
         nom,
-        adresse: banData.nom,
-        commune: banData.commune,
-        codePostal: banData.codePostal,
-        codeInsee: banData.codeInsee,
-        latitude: banData.latitude,
-        longitude: banData.longitude,
+        adresse: trustedBanData.nom,
+        commune: trustedBanData.commune,
+        codePostal: trustedBanData.codePostal,
+        codeInsee: trustedBanData.codeInsee,
+        latitude: trustedBanData.latitude,
+        longitude: trustedBanData.longitude,
         nomReferent,
         courrielReferent,
         telephoneReferent,

--- a/apps/web/src/jobs/apply-corriger-adresse/executeApplyCorrigerAdresse.ts
+++ b/apps/web/src/jobs/apply-corriger-adresse/executeApplyCorrigerAdresse.ts
@@ -144,7 +144,15 @@ export const executeApplyCorrigerAdresse = async (
           const codePostalApi = adresse.code_postal
           const codeInseeApi = adresse.code_commune ?? ''
 
-          if (adresseApi) {
+          // Les établissements non-diffusibles renvoient '[NON-DIFFUSIBLE]'
+          // dans tous les champs. code_postal/code_insee sont en VarChar(5) :
+          // on ne retient la donnée SIRET que si ces codes ont un format
+          // valide, sinon on bascule sur le fallback BAN (stratégie 2).
+          const codePostalValide = /^\d{5}$/.test(codePostalApi)
+          const codeInseeValide =
+            codeInseeApi === '' || /^(\d{2}|2[AB])\d{3}$/i.test(codeInseeApi)
+
+          if (adresseApi && codePostalValide && codeInseeValide) {
             // Géocoder l'adresse API Entreprise via BAN
             const fullAdresse = `${adresseApi}, ${codePostalApi} ${communeApi}`
             const feature = await searchAdresse(fullAdresse)

--- a/apps/web/src/jobs/apply-review-to-action-plan/executeApplyReviewToActionPlan.ts
+++ b/apps/web/src/jobs/apply-review-to-action-plan/executeApplyReviewToActionPlan.ts
@@ -11,36 +11,69 @@ type ReviewRow = {
   statut: string // 'a_fusionner' | ''
 }
 
-const parseReviewCsv = (content: string): ReviewRow[] => {
-  const lines = content.split('\n')
-  const rows: ReviewRow[] = []
-
-  for (const line of lines.slice(1)) {
-    const clean = line.replace(/\r$/, '')
-    if (!clean.trim()) continue
-
-    const fields: string[] = []
-    let current = ''
-    let inQuotes = false
-    for (const char of clean) {
-      if (char === '"') {
-        inQuotes = !inQuotes
-      } else if (char === ';' && !inQuotes) {
-        fields.push(current)
-        current = ''
-      } else {
-        current += char
-      }
+const splitCsvLine = (line: string): string[] => {
+  const fields: string[] = []
+  let current = ''
+  let inQuotes = false
+  for (const char of line) {
+    if (char === '"') {
+      inQuotes = !inQuotes
+    } else if (char === ';' && !inQuotes) {
+      fields.push(current)
+      current = ''
+    } else {
+      current += char
     }
-    fields.push(current)
-
-    const [clusterId, id, role, statut] = fields
-    if (!clusterId || !id) continue
-
-    rows.push({ clusterId, id, role, statut })
   }
+  fields.push(current)
+  return fields
+}
 
-  return rows
+// Column order changed across Tim's review batches:
+//   batch1.x : cluster_id;id;role;statut;…   (with header)
+//   batch2   : cluster_id;id;role;statut;…   (no header)
+//   3juin    : cluster_id;role;statut;id;…   (with header)
+// Resolve indices from the header when present, otherwise fall back to the
+// legacy positional order. This keeps every batch parseable.
+const LEGACY_INDICES = { clusterId: 0, id: 1, role: 2, statut: 3 }
+const HEADER_TOKENS = ['cluster_id', 'id', 'role', 'statut']
+
+const parseReviewCsv = (content: string): ReviewRow[] => {
+  const lines = content
+    .split('\n')
+    .map((line) => line.replace(/\r$/, ''))
+    .filter((line) => line.trim())
+
+  if (lines.length === 0) return []
+
+  const firstFields = splitCsvLine(lines[0]).map((field) => field.trim())
+  const hasHeader = firstFields.some((field) => HEADER_TOKENS.includes(field))
+
+  const indices = hasHeader
+    ? {
+        clusterId: firstFields.indexOf('cluster_id'),
+        id: firstFields.indexOf('id'),
+        role: firstFields.indexOf('role'),
+        statut: firstFields.indexOf('statut'),
+      }
+    : LEGACY_INDICES
+
+  const dataLines = hasHeader ? lines.slice(1) : lines
+
+  return dataLines.reduce<ReviewRow[]>((rows, line) => {
+    const fields = splitCsvLine(line)
+    const clusterId = fields[indices.clusterId]
+    const id = fields[indices.id]
+    if (!clusterId || !id) return rows
+
+    rows.push({
+      clusterId,
+      id,
+      role: fields[indices.role] ?? '',
+      statut: fields[indices.statut] ?? '',
+    })
+    return rows
+  }, [])
 }
 
 export const executeApplyReviewToActionPlan = async (


### PR DESCRIPTION
Le code_insee du payload Dataspace diverge parfois de celui géocodé (siège vs antenne), ce qui faisait rater le findFirst (siret, codeInsee) et recréer une structure pourtant déjà active. findOrCreateStructure géocode désormais une seule fois en amont et réutilise le code_insee résolu pour toutes les recherches ET la création (symétrie recherche/stockage). Garde-fou de cohérence départementale pour neutraliser le mis-géocodage BAN des adresses ultra-marines (97/98).

Validé sur export prod : 19/20 doublons post-fix évités, le 20e étant un multi-site légitime correctement distingué.