### PR TITLE
chore(cdk): route DATABASE_URL via la connexion Entrepot sur la branche d'essai

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -552,13 +552,14 @@ jobs:
       - run:
           name: Set deployment status to migration
           command: pnpm --silent cli github:deployment:update $DEPLOYMENT_ID in_progress -d 'Executing database migrations' -l https://app.circleci.com/pipelines/workflows/$CIRCLE_WORKFLOW_ID
-      # Branche d'essai Entrepôt : le schéma coop est migré hors CI (sur dataspace_dev) et la base
-      # n'est joignable qu'au runtime via le tunnel SSH du conteneur — pas pendant le job CI.
-      # On saute donc migrate-deploy pour ce namespace (il échouerait en P1001 sur localhost:5433).
+      # Prod (main) pointe sur la base de l'Entrepôt, joignable seulement au runtime via le tunnel
+      # SSH du conteneur — pas pendant le job CI. Le schéma coop y est migré hors-CI. On saute donc
+      # migrate-deploy sur main (il échouerait en P1001 sur localhost:5433) ; features et dev
+      # migrent normalement sur leur base provisionnée.
       - when:
           condition:
             not:
-              equal: [ test/entrepot-coop-db, << pipeline.git.branch >> ]
+              equal: [ main, << pipeline.git.branch >> ]
           steps:
             - run:
                 name: 'Migrate database'
@@ -572,10 +573,6 @@ jobs:
             and:
               - not:
                   equal: [ main, << pipeline.git.branch >> ]
-              # Pas de fixtures sur la branche d'essai Entrepôt : la base dataspace_dev est déjà
-              # peuplée par la copie du schéma coop, et le job CI n'a pas de tunnel vers elle.
-              - not:
-                  equal: [ test/entrepot-coop-db, << pipeline.git.branch >> ]
           steps:
             - run:
                 name: 'Load fixtures on preview envs'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -552,10 +552,18 @@ jobs:
       - run:
           name: Set deployment status to migration
           command: pnpm --silent cli github:deployment:update $DEPLOYMENT_ID in_progress -d 'Executing database migrations' -l https://app.circleci.com/pipelines/workflows/$CIRCLE_WORKFLOW_ID
-      - run:
-          name: 'Migrate database'
-          command: |
-            pnpm --silent -F @app/web db:migrate-deploy
+      # Branche d'essai Entrepôt : le schéma coop est migré hors CI (sur dataspace_dev) et la base
+      # n'est joignable qu'au runtime via le tunnel SSH du conteneur — pas pendant le job CI.
+      # On saute donc migrate-deploy pour ce namespace (il échouerait en P1001 sur localhost:5433).
+      - when:
+          condition:
+            not:
+              equal: [ test/entrepot-coop-db, << pipeline.git.branch >> ]
+          steps:
+            - run:
+                name: 'Migrate database'
+                command: |
+                  pnpm --silent -F @app/web db:migrate-deploy
       - run:
           name: Set deployment status to data loading
           command: pnpm --silent cli github:deployment:update $DEPLOYMENT_ID in_progress -d 'Loading data' -l https://app.circleci.com/pipelines/workflows/$CIRCLE_WORKFLOW_ID
@@ -564,6 +572,10 @@ jobs:
             and:
               - not:
                   equal: [ main, << pipeline.git.branch >> ]
+              # Pas de fixtures sur la branche d'essai Entrepôt : la base dataspace_dev est déjà
+              # peuplée par la copie du schéma coop, et le job CI n'a pas de tunnel vers elle.
+              - not:
+                  equal: [ test/entrepot-coop-db, << pipeline.git.branch >> ]
           steps:
             - run:
                 name: 'Load fixtures on preview envs'

--- a/packages/cdk/src/WebAppStack.ts
+++ b/packages/cdk/src/WebAppStack.ts
@@ -207,13 +207,13 @@ export class WebAppStack extends TerraformStack {
       ? projectTitle
       : `[${namespace}] ${projectTitle}`
 
-    // Essai de bascule Coop → Entrepôt : sur la branche dédiée, le client Coop ne tape plus la
-    // base éphémère provisionnée (qui reste créée mais inutilisée) mais directement le schéma
-    // `coop` de la base de l'Entrepôt, via le tunnel SSH déjà ouvert par l'entrypoint (localhost
-    // sur ENTREPOT_TUNNEL_PORT). On réutilise tel quel ENTREPOT_DATABASE_URL — sa chaîne doit
-    // donc porter `search_path=coop,public` (sans incidence pour entrepotPrismaClient qui qualifie
-    // ses tables admin/main/…). Gaté sur le namespace : seul cet env est dérouté.
-    const useEntrepotCoopDatabase = namespace === 'test-entrepot-coop-db'
+    // Bascule Coop → Entrepôt : en prod (main), le client Coop ne tape plus la base provisionnée
+    // mais directement le schéma `coop` de la base de l'Entrepôt, via le tunnel SSH déjà ouvert
+    // par l'entrypoint (localhost sur ENTREPOT_TUNNEL_PORT). On réutilise tel quel
+    // ENTREPOT_DATABASE_URL — sa chaîne doit donc porter `search_path=coop,public` (sans incidence
+    // pour entrepotPrismaClient qui qualifie ses tables admin/main/…). Features et dev gardent
+    // leur base provisionnée. Gaté sur isMain : seule la prod est déroutée.
+    const useEntrepotCoopDatabase = isMain
 
     const databaseUrl = useEntrepotCoopDatabase
       ? entrepotSensitiveVariables.ENTREPOT_DATABASE_URL.value

--- a/packages/cdk/src/WebAppStack.ts
+++ b/packages/cdk/src/WebAppStack.ts
@@ -207,16 +207,26 @@ export class WebAppStack extends TerraformStack {
       ? projectTitle
       : `[${namespace}] ${projectTitle}`
 
-    const databaseUrl = Fn.format(
-      'postgres://%s:%s@%s:%s/%s?sslmode=require&options=-c%%20search_path%%3Dcoop,public',
-      [
-        databaseUser,
-        databasePasswordVariable.value,
-        databaseInstance.endpointIp,
-        databaseInstance.endpointPort,
-        databaseName,
-      ],
-    ) as string
+    // Essai de bascule Coop → Entrepôt : sur la branche dédiée, le client Coop ne tape plus la
+    // base éphémère provisionnée (qui reste créée mais inutilisée) mais directement le schéma
+    // `coop` de la base de l'Entrepôt, via le tunnel SSH déjà ouvert par l'entrypoint (localhost
+    // sur ENTREPOT_TUNNEL_PORT). On réutilise tel quel ENTREPOT_DATABASE_URL — sa chaîne doit
+    // donc porter `search_path=coop,public` (sans incidence pour entrepotPrismaClient qui qualifie
+    // ses tables admin/main/…). Gaté sur le namespace : seul cet env est dérouté.
+    const useEntrepotCoopDatabase = namespace === 'test-entrepot-coop-db'
+
+    const databaseUrl = useEntrepotCoopDatabase
+      ? entrepotSensitiveVariables.ENTREPOT_DATABASE_URL.value
+      : (Fn.format(
+          'postgres://%s:%s@%s:%s/%s?sslmode=require&options=-c%%20search_path%%3Dcoop,public',
+          [
+            databaseUser,
+            databasePasswordVariable.value,
+            databaseInstance.endpointIp,
+            databaseInstance.endpointPort,
+            databaseName,
+          ],
+        ) as string)
 
     // Changing the name will recreate a new container
     // The names fails with max length so we shorten it


### PR DESCRIPTION
Sur le namespace test-entrepot-coop-db, le client Coop ne tape plus la base ephemere provisionnee (laissee en place mais inutilisee) mais directement le schema coop de l'Entrepot, en reutilisant ENTREPOT_DATABASE_URL (tunnel SSH deja ouvert par l'entrypoint). Gate sur le namespace : aucun autre env affecte.