### PR TITLE
fix(beneficiaire): conserve la tranche d'âge saisie et formate l'affichage des téléphones

### DIFF
--- a/apps/web/src/features/beneficiaire/abilities/consulter-beneficiaire/ui/components/BeneficiaireCoordonnees.tsx
+++ b/apps/web/src/features/beneficiaire/abilities/consulter-beneficiaire/ui/components/BeneficiaireCoordonnees.tsx
@@ -1,4 +1,5 @@
 import InfoLabelValue from '@app/web/components/InfoLabelValue'
+import { telephoneDisplayString } from '@app/web/features/beneficiaire/domain/telephone'
 import type { BeneficiaireInformations } from '../../domain/consulter-beneficiaire'
 
 const BeneficiaireCoordonnees = ({
@@ -17,7 +18,13 @@ const BeneficiaireCoordonnees = ({
       <div className="fr-col-6">
         <InfoLabelValue
           label="Numéro de téléphone"
-          value={pasDeTelephone ? 'Pas de téléphone' : telephone || '-'}
+          value={
+            pasDeTelephone
+              ? 'Pas de téléphone'
+              : telephone
+                ? telephoneDisplayString(telephone)
+                : '-'
+          }
         />
       </div>
       <div className="fr-col-6">

--- a/apps/web/src/features/beneficiaire/abilities/creer-beneficiaire/action/creer-beneficiaire.validation.spec.ts
+++ b/apps/web/src/features/beneficiaire/abilities/creer-beneficiaire/action/creer-beneficiaire.validation.spec.ts
@@ -12,6 +12,7 @@ describe('CreerBeneficiaireValidation', () => {
       anneeNaissance: null,
       communeResidence: null,
       genre: 'NonCommunique',
+      trancheAge: 'NonCommunique',
       statutSocial: 'NonCommunique',
       notes: null,
     })
@@ -98,11 +99,11 @@ describe('CreerBeneficiaireValidation', () => {
     })
   })
 
-  it('ignores any trancheAge sent by the form (derived from année)', () => {
+  it('keeps the trancheAge selected in the form', () => {
     const result = CreerBeneficiaireValidation.parse({
       ...minimal,
       trancheAge: 'SoixanteDixPlus',
     })
-    expect(result).not.toHaveProperty('trancheAge')
+    expect(result.trancheAge).toBe('SoixanteDixPlus')
   })
 })

--- a/apps/web/src/features/beneficiaire/abilities/creer-beneficiaire/action/creer-beneficiaire.validation.ts
+++ b/apps/web/src/features/beneficiaire/abilities/creer-beneficiaire/action/creer-beneficiaire.validation.ts
@@ -13,6 +13,7 @@ export const CreerBeneficiaireValidation = beneficiaireFormShape.transform(
     anneeNaissance: form.anneeNaissance ?? null,
     communeResidence: form.communeResidence ?? null,
     genre: Genre(form.genre),
+    trancheAge: form.trancheAge,
     statutSocial: StatutSocial(form.statutSocial),
     notes: form.notes ?? null,
   }),

--- a/apps/web/src/features/beneficiaire/abilities/creer-beneficiaire/creer-beneficiaire.ability.md
+++ b/apps/web/src/features/beneficiaire/abilities/creer-beneficiaire/creer-beneficiaire.ability.md
@@ -15,14 +15,23 @@
   | anonyme | false  |
 * And le compteur de bénéficiaires du médiateur est incrémenté de 1
 
-## Rule: La tranche d'âge est dérivée de l'année de naissance
+## Rule: La tranche d'âge est dérivée de l'année de naissance, sinon la saisie est conservée
 
 ### Scenario: Avec une année de naissance, la tranche est calculée
 
 * When je crée un bénéficiaire né en 1990
 * Then la tranche d'âge du bénéficiaire est "VingtCinqTrenteNeuf"
 
-### Scenario: Sans année de naissance, la tranche est "NonCommunique"
+### Scenario: Sans année de naissance, la tranche saisie est conservée
+
+* When je crée un bénéficiaire avec les données suivantes
+  | Champ      | Valeur          |
+  | prenom     | Marie           |
+  | nom        | Curie           |
+  | trancheAge | SoixanteDixPlus |
+* Then la tranche d'âge du bénéficiaire est "SoixanteDixPlus"
+
+### Scenario: Sans année de naissance ni tranche saisie, la tranche est "NonCommunique"
 
 * When je crée un bénéficiaire avec les données suivantes
   | Champ  | Valeur |

--- a/apps/web/src/features/beneficiaire/abilities/creer-beneficiaire/creer-beneficiaire.steps.ts
+++ b/apps/web/src/features/beneficiaire/abilities/creer-beneficiaire/creer-beneficiaire.steps.ts
@@ -26,7 +26,11 @@ When(
   'je crée un bénéficiaire avec les données suivantes',
   async (dataTable: DataTable) => {
     const data = Object.fromEntries(dataTable.rows())
-    await creer({ prenom: data.prenom, nom: data.nom })
+    await creer({
+      prenom: data.prenom,
+      nom: data.nom,
+      trancheAge: data.trancheAge,
+    })
   },
 )
 

--- a/apps/web/src/features/beneficiaire/abilities/creer-beneficiaire/domain/creer-beneficiaire.ts
+++ b/apps/web/src/features/beneficiaire/abilities/creer-beneficiaire/domain/creer-beneficiaire.ts
@@ -9,6 +9,7 @@ import type { Nom } from '@app/web/features/beneficiaire/domain/nom'
 import type { Notes } from '@app/web/features/beneficiaire/domain/notes'
 import type { Prenom } from '@app/web/features/beneficiaire/domain/prenom'
 import type { StatutSocial } from '@app/web/features/beneficiaire/domain/statut-social'
+import type { TrancheAge } from '@app/web/features/beneficiaire/domain/tranche-age'
 
 /**
  * Input validé pour créer un bénéficiaire : les attributs éditables, sans
@@ -22,6 +23,7 @@ export type BeneficiaireACreer = {
   readonly anneeNaissance: AnneeNaissance | null
   readonly communeResidence: CommuneResidence | null
   readonly genre: Genre
+  readonly trancheAge: TrancheAge
   readonly statutSocial: StatutSocial
   readonly notes: Notes | null
 }

--- a/apps/web/src/features/beneficiaire/abilities/detecter-doublons/ui/components/BeneficiaireFusionDoublons.tsx
+++ b/apps/web/src/features/beneficiaire/abilities/detecter-doublons/ui/components/BeneficiaireFusionDoublons.tsx
@@ -7,6 +7,7 @@ import type {
   BeneficiaireDoublon,
   DetecterDoublons,
 } from '@app/web/features/beneficiaire/abilities/detecter-doublons'
+import { telephoneDisplayString } from '@app/web/features/beneficiaire/domain/telephone'
 import { pluriel } from '@app/web/libraries/pluriel'
 import { numberToString } from '@app/web/utils/formatNumber'
 import Button from '@codegouvfr/react-dsfr/Button'
@@ -346,4 +347,6 @@ const formatDisplayName = (
 }
 
 const formatDisplayPhone = (telephone?: string | null): string =>
-  telephone && telephone.trim().length > 0 ? telephone : '/'
+  telephone && telephone.trim().length > 0
+    ? telephoneDisplayString(telephone)
+    : '/'

--- a/apps/web/src/features/beneficiaire/abilities/exporter-beneficiaires/implementation/build-beneficiaires-worksheet.ts
+++ b/apps/web/src/features/beneficiaire/abilities/exporter-beneficiaires/implementation/build-beneficiaires-worksheet.ts
@@ -3,6 +3,7 @@ import {
   statutSocialLabels,
   trancheAgeLabels,
 } from '@app/web/features/beneficiaire/domain'
+import { telephoneDisplayString } from '@app/web/features/beneficiaire/domain/telephone'
 import { addExportMetadata } from '@app/web/libs/worksheet/addExportMetadata'
 import { addTitleRow } from '@app/web/libs/worksheet/addTitleRow'
 import { autosizeColumns } from '@app/web/libs/worksheet/autosizeColumns'
@@ -37,7 +38,7 @@ const toRow = (beneficiaire: BeneficiaireExportRow) => [
   beneficiaire.communeResidence?.commune ?? '-',
   beneficiaire.communeResidence?.codeInsee ?? '-',
   beneficiaire.communeResidence?.codePostal ?? '-',
-  beneficiaire.telephone ?? '-',
+  beneficiaire.telephone ? telephoneDisplayString(beneficiaire.telephone) : '-',
   beneficiaire.email ?? '-',
   sexLabels[beneficiaire.genre],
   trancheAgeLabels[beneficiaire.trancheAge],

--- a/apps/web/src/features/beneficiaire/abilities/importer-beneficiaires/action/importer-beneficiaires.validation.spec.ts
+++ b/apps/web/src/features/beneficiaire/abilities/importer-beneficiaires/action/importer-beneficiaires.validation.spec.ts
@@ -24,6 +24,7 @@ describe('ImporterBeneficiairesValidation', () => {
         anneeNaissance: null,
         communeResidence: null,
         genre: 'NonCommunique',
+        trancheAge: 'NonCommunique',
         statutSocial: 'NonCommunique',
         notes: null,
       },

--- a/apps/web/src/features/beneficiaire/abilities/importer-beneficiaires/action/importer-beneficiaires.validation.ts
+++ b/apps/web/src/features/beneficiaire/abilities/importer-beneficiaires/action/importer-beneficiaires.validation.ts
@@ -12,6 +12,7 @@ import { Notes } from '@app/web/features/beneficiaire/domain/notes'
 import { Prenom } from '@app/web/features/beneficiaire/domain/prenom'
 import { StatutSocial } from '@app/web/features/beneficiaire/domain/statut-social'
 import { Telephone } from '@app/web/features/beneficiaire/domain/telephone'
+import { TrancheAge } from '@app/web/features/beneficiaire/domain/tranche-age'
 import type { z } from 'zod'
 import type { BeneficiaireAImporter } from '../domain/importer-beneficiaires'
 
@@ -61,6 +62,7 @@ const toBeneficiaireAImporter = (
         })
       : null,
     genre: Genre(row.parsed.genre),
+    trancheAge: TrancheAge(null),
     statutSocial: StatutSocial(null),
     notes: parseOptional(Notes.schema, row.values.notesSupplementaires),
   }

--- a/apps/web/src/features/beneficiaire/abilities/importer-beneficiaires/domain/importer-beneficiaires.ts
+++ b/apps/web/src/features/beneficiaire/abilities/importer-beneficiaires/domain/importer-beneficiaires.ts
@@ -8,6 +8,7 @@ import type { Nom } from '@app/web/features/beneficiaire/domain/nom'
 import type { Notes } from '@app/web/features/beneficiaire/domain/notes'
 import type { Prenom } from '@app/web/features/beneficiaire/domain/prenom'
 import type { StatutSocial } from '@app/web/features/beneficiaire/domain/statut-social'
+import type { TrancheAge } from '@app/web/features/beneficiaire/domain/tranche-age'
 
 /**
  * Input validé pour importer un bénéficiaire : les attributs éditables issus
@@ -22,6 +23,7 @@ export type BeneficiaireAImporter = {
   readonly anneeNaissance: AnneeNaissance | null
   readonly communeResidence: CommuneResidence | null
   readonly genre: Genre
+  readonly trancheAge: TrancheAge
   readonly statutSocial: StatutSocial
   readonly notes: Notes | null
 }

--- a/apps/web/src/features/beneficiaire/abilities/importer-beneficiaires/importer-beneficiaires.steps.ts
+++ b/apps/web/src/features/beneficiaire/abilities/importer-beneficiaires/importer-beneficiaires.steps.ts
@@ -9,6 +9,7 @@ import { Genre } from '@app/web/features/beneficiaire/domain/genre'
 import { Nom } from '@app/web/features/beneficiaire/domain/nom'
 import { Prenom } from '@app/web/features/beneficiaire/domain/prenom'
 import { StatutSocial } from '@app/web/features/beneficiaire/domain/statut-social'
+import { TrancheAge } from '@app/web/features/beneficiaire/domain/tranche-age'
 import { prismaClient } from '@app/web/prismaClient'
 import { Then, When } from '@cucumber/cucumber'
 
@@ -25,6 +26,7 @@ const beneficiaireAImporter = (
   anneeNaissance: null,
   communeResidence: null,
   genre: Genre(null),
+  trancheAge: TrancheAge(null),
   statutSocial: StatutSocial(null),
   notes: null,
 })

--- a/apps/web/src/features/beneficiaire/abilities/modifier-beneficiaire/action/modifier-beneficiaire.validation.spec.ts
+++ b/apps/web/src/features/beneficiaire/abilities/modifier-beneficiaire/action/modifier-beneficiaire.validation.spec.ts
@@ -14,9 +14,19 @@ describe('ModifierBeneficiaireValidation', () => {
       anneeNaissance: null,
       communeResidence: null,
       genre: 'NonCommunique',
+      trancheAge: 'NonCommunique',
       statutSocial: 'NonCommunique',
       notes: null,
     })
+  })
+
+  it('keeps the trancheAge selected in the form', () => {
+    expect(
+      ModifierBeneficiaireValidation.parse({
+        ...minimal,
+        trancheAge: 'SoixanteDixPlus',
+      }).trancheAge,
+    ).toBe('SoixanteDixPlus')
   })
 
   it('requires a valid uuid id', () => {

--- a/apps/web/src/features/beneficiaire/abilities/modifier-beneficiaire/action/modifier-beneficiaire.validation.ts
+++ b/apps/web/src/features/beneficiaire/abilities/modifier-beneficiaire/action/modifier-beneficiaire.validation.ts
@@ -17,6 +17,7 @@ export const ModifierBeneficiaireValidation = beneficiaireFormShape
       anneeNaissance: form.anneeNaissance ?? null,
       communeResidence: form.communeResidence ?? null,
       genre: Genre(form.genre),
+      trancheAge: form.trancheAge,
       statutSocial: StatutSocial(form.statutSocial),
       notes: form.notes ?? null,
     }),

--- a/apps/web/src/features/beneficiaire/abilities/modifier-beneficiaire/domain/beneficiaire-a-modifier.ts
+++ b/apps/web/src/features/beneficiaire/abilities/modifier-beneficiaire/domain/beneficiaire-a-modifier.ts
@@ -11,6 +11,7 @@ import type { Nom } from '@app/web/features/beneficiaire/domain/nom'
 import type { Notes } from '@app/web/features/beneficiaire/domain/notes'
 import type { Prenom } from '@app/web/features/beneficiaire/domain/prenom'
 import type { StatutSocial } from '@app/web/features/beneficiaire/domain/statut-social'
+import type { TrancheAge } from '@app/web/features/beneficiaire/domain/tranche-age'
 import type { Result } from '@app/web/libraries/result'
 
 /**
@@ -26,6 +27,7 @@ export type BeneficiaireAModifier = {
   readonly anneeNaissance: AnneeNaissance | null
   readonly communeResidence: CommuneResidence | null
   readonly genre: Genre
+  readonly trancheAge: TrancheAge
   readonly statutSocial: StatutSocial
   readonly notes: Notes | null
 }

--- a/apps/web/src/features/beneficiaire/abilities/modifier-beneficiaire/modifier-beneficiaire.ability.md
+++ b/apps/web/src/features/beneficiaire/abilities/modifier-beneficiaire/modifier-beneficiaire.ability.md
@@ -20,6 +20,21 @@
 * When je modifie un bénéficiaire inexistant
 * Then la modification échoue avec l'erreur "BeneficiaireNotFound"
 
+## Rule: La tranche d'âge saisie sans année de naissance est conservée
+
+### Scenario: Renseigner la tranche d'âge sans année de naissance
+
+* Given un bénéficiaire "Jean Dupont" de ce médiateur
+* When je modifie ce bénéficiaire avec les données suivantes
+  | Champ      | Valeur          |
+  | prenom     | Jean            |
+  | nom        | Dupont          |
+  | trancheAge | SoixanteDixPlus |
+* Then la modification réussit
+* And le bénéficiaire porte désormais les données suivantes
+  | Champ      | Valeur          |
+  | trancheAge | SoixanteDixPlus |
+
 ## Rule: La date de création est préservée à la modification
 
 ### Scenario: La date de création reste inchangée

--- a/apps/web/src/features/beneficiaire/abilities/modifier-beneficiaire/modifier-beneficiaire.steps.ts
+++ b/apps/web/src/features/beneficiaire/abilities/modifier-beneficiaire/modifier-beneficiaire.steps.ts
@@ -36,6 +36,7 @@ When(
       id: targetId,
       prenom: data.prenom,
       nom: data.nom,
+      trancheAge: data.trancheAge,
     })
     result = await modifierBeneficiaire({
       beneficiaire,

--- a/apps/web/src/features/beneficiaire/abilities/modifier-beneficiaire/ui/components/modifier-beneficiaire.presenter.ts
+++ b/apps/web/src/features/beneficiaire/abilities/modifier-beneficiaire/ui/components/modifier-beneficiaire.presenter.ts
@@ -1,5 +1,6 @@
 import type { BeneficiaireAEditer } from '@app/web/features/beneficiaire/abilities/modifier-beneficiaire/domain/beneficiaire-a-editer'
 import { displayNameFromIdentity } from '@app/web/features/beneficiaire/domain/beneficiaire'
+import { telephoneDisplayString } from '@app/web/features/beneficiaire/domain/telephone'
 import type { BeneficiaireData } from '@app/web/features/beneficiaire/forms/beneficiaire-validation'
 import type { Beneficiaire } from '@prisma/client'
 import type { DefaultValues } from 'react-hook-form'
@@ -80,7 +81,7 @@ export const presentBeneficiaireAModifier = ({
       communeResidence,
       anneeNaissance,
       pasDeTelephone,
-      telephone,
+      telephone: telephone ? telephoneDisplayString(telephone) : telephone,
       email,
       prenom: prenom ?? '',
       nom: nom ?? '',

--- a/apps/web/src/features/beneficiaire/domain/beneficiaire.spec.ts
+++ b/apps/web/src/features/beneficiaire/domain/beneficiaire.spec.ts
@@ -137,15 +137,26 @@ describe('AnneeNaissance', () => {
 })
 
 describe('trancheAgeForBeneficiaire', () => {
-  it('returns NonCommunique without année de naissance', () => {
-    expect(trancheAgeForBeneficiaire(null)).toBe('NonCommunique')
+  it('returns NonCommunique without année de naissance ni tranche saisie', () => {
+    expect(trancheAgeForBeneficiaire(null, TrancheAge(null))).toBe(
+      'NonCommunique',
+    )
   })
 
-  it('derives the tranche from the année de naissance', () => {
-    const currentYear = new Date().getFullYear()
-    expect(trancheAgeForBeneficiaire(AnneeNaissance(currentYear - 30))).toBe(
-      'VingtCinqTrenteNeuf',
+  it('keeps the tranche saisie without année de naissance', () => {
+    expect(trancheAgeForBeneficiaire(null, TrancheAge('SoixanteDixPlus'))).toBe(
+      'SoixanteDixPlus',
     )
+  })
+
+  it('derives the tranche from the année de naissance, over the saisie', () => {
+    const currentYear = new Date().getFullYear()
+    expect(
+      trancheAgeForBeneficiaire(
+        AnneeNaissance(currentYear - 30),
+        TrancheAge('SoixanteDixPlus'),
+      ),
+    ).toBe('VingtCinqTrenteNeuf')
   })
 })
 
@@ -163,6 +174,7 @@ describe('toBeneficiaireIdentifie', () => {
     anneeNaissance: null,
     communeResidence: null,
     genre: Genre('NonCommunique'),
+    trancheAge: TrancheAge('NonCommunique'),
     statutSocial: StatutSocial('NonCommunique'),
     notes: null,
   } satisfies Parameters<typeof toBeneficiaireIdentifie>[0]
@@ -196,6 +208,15 @@ describe('toBeneficiaireIdentifie', () => {
         { id, mediateurId, creation, modification },
       ).trancheAge,
     ).toBe('MoinsDeDouze')
+  })
+
+  it('keeps the trancheAge saisie when anneeNaissance is absent', () => {
+    expect(
+      toBeneficiaireIdentifie(
+        { ...minimal, trancheAge: TrancheAge('SoixanteDixPlus') },
+        { id, mediateurId, creation, modification },
+      ).trancheAge,
+    ).toBe('SoixanteDixPlus')
   })
 
   it('preserves the structured value objects', () => {

--- a/apps/web/src/features/beneficiaire/domain/beneficiaire.ts
+++ b/apps/web/src/features/beneficiaire/domain/beneficiaire.ts
@@ -91,6 +91,7 @@ export const toBeneficiaireIdentifie = (
     | 'anneeNaissance'
     | 'communeResidence'
     | 'genre'
+    | 'trancheAge'
     | 'statutSocial'
     | 'notes'
   >,
@@ -118,7 +119,10 @@ export const toBeneficiaireIdentifie = (
   notes: attributs.notes,
   genre: attributs.genre,
   statutSocial: attributs.statutSocial,
-  trancheAge: trancheAgeForBeneficiaire(attributs.anneeNaissance),
+  trancheAge: trancheAgeForBeneficiaire(
+    attributs.anneeNaissance,
+    attributs.trancheAge,
+  ),
   creation,
   modification,
   suppression: null,

--- a/apps/web/src/features/beneficiaire/domain/telephone.spec.ts
+++ b/apps/web/src/features/beneficiaire/domain/telephone.spec.ts
@@ -1,4 +1,4 @@
-import { Telephone } from './telephone'
+import { Telephone, telephoneDisplayString } from './telephone'
 
 describe('Telephone', () => {
   it.each([
@@ -29,5 +29,30 @@ describe('Telephone', () => {
     '00112030405',
   ])('rejects the invalid number %s', (value) => {
     expect(() => Telephone(value)).toThrow()
+  })
+})
+
+describe('telephoneDisplayString', () => {
+  it.each([
+    ['+33102030405', '01 02 03 04 05'],
+    ['+33612345678', '06 12 34 56 78'],
+    ['+262262202020', '02 62 20 20 20'], // La Réunion
+    ['+262269600102', '02 69 60 01 02'], // Mayotte
+    ['+590690000001', '06 90 00 00 01'], // Guadeloupe
+    ['+352621365161', '+352 621365161'], // Luxembourg : indicatif détaché
+  ])('formats the canonical %s as %s', (input, expected) => {
+    expect(telephoneDisplayString(input)).toBe(expected)
+  })
+
+  it.each([
+    ['0102030405', '01 02 03 04 05'],
+    ['01.02.03.04.05', '01 02 03 04 05'],
+    ['01 02 03 04 05', '01 02 03 04 05'],
+  ])('formats the legacy national %s as %s', (input, expected) => {
+    expect(telephoneDisplayString(input)).toBe(expected)
+  })
+
+  it('returns an unrecognized value unchanged', () => {
+    expect(telephoneDisplayString('poste 1234')).toBe('poste 1234')
   })
 })

--- a/apps/web/src/features/beneficiaire/domain/telephone.ts
+++ b/apps/web/src/features/beneficiaire/domain/telephone.ts
@@ -41,3 +41,26 @@ export const Telephone = defineModel(
 )
 
 export type Telephone = Model.TypeOf<typeof Telephone>
+
+// Indicatifs dont les numéros se recomposent en format national français
+// (0 + 9 chiffres) : métropole et outre-mer.
+const INDICATIF_NATIONAL = /^\+(?:33|262|590|594|596)(\d{9})$/
+
+const parPaires = (chiffres: string): string =>
+  chiffres.replace(/(\d{2})(?=\d)/g, '$1 ')
+
+/**
+ * Format d'affichage « humain » : national par paires (`01 02 03 04 05`) pour
+ * la métropole et l'outre-mer, indicatif détaché pour les autres pays.
+ * Accepte `string` (pas seulement `Telephone`) : les frontières UI affichent
+ * aussi des valeurs persistées avant la normalisation canonique, rendues
+ * telles quelles si non reconnues.
+ */
+export const telephoneDisplayString = (telephone: string): string => {
+  const compact = telephone.replace(/[\s()./-]/g, '')
+  const national = compact.match(INDICATIF_NATIONAL)
+  if (national) return parPaires(`0${national[1]}`)
+  if (/^0\d{9}$/.test(compact)) return parPaires(compact)
+  const international = compact.match(/^(\+\d{3})(\d+)$/)
+  return international ? `${international[1]} ${international[2]}` : telephone
+}

--- a/apps/web/src/features/beneficiaire/domain/tranche-age.ts
+++ b/apps/web/src/features/beneficiaire/domain/tranche-age.ts
@@ -58,15 +58,16 @@ export const trancheAgeFromAnneeNaissance = (
   )
 
 /**
- * La tranche d'âge est dérivée de l'année de naissance (règle métier),
- * jamais saisie directement. Sans année de naissance : `NonCommunique`.
+ * L'année de naissance fait foi : quand elle est renseignée, la tranche d'âge
+ * en est dérivée (règle métier). Sans année, la tranche saisie est conservée.
  */
 export const trancheAgeForBeneficiaire = (
   anneeNaissance: AnneeNaissance | null,
+  trancheAgeSaisie: TrancheAge,
 ): TrancheAge =>
   anneeNaissance
     ? trancheAgeFromAnneeNaissance(anneeNaissance)
-    : TrancheAge('NonCommunique')
+    : trancheAgeSaisie
 
 /**
  * Dérive la tranche d'âge d'une année « brute » (valeur de formulaire ou source

--- a/apps/web/src/features/beneficiaire/forms/beneficiaire-form.ts
+++ b/apps/web/src/features/beneficiaire/forms/beneficiaire-form.ts
@@ -7,6 +7,7 @@ import { Notes } from '@app/web/features/beneficiaire/domain/notes'
 import { Prenom } from '@app/web/features/beneficiaire/domain/prenom'
 import { statutsSociaux } from '@app/web/features/beneficiaire/domain/statut-social'
 import { Telephone } from '@app/web/features/beneficiaire/domain/telephone'
+import { TrancheAge } from '@app/web/features/beneficiaire/domain/tranche-age'
 import { optional } from '@app/web/libraries/zod'
 import { z } from 'zod'
 
@@ -48,6 +49,7 @@ export const beneficiaireFormShape = z.object({
   anneeNaissance: optional(AnneeNaissance.schema),
   communeResidence: CommuneResidenceForm.nullish(),
   genre: z.enum(genres).nullish(),
+  trancheAge: TrancheAge.schema,
   statutSocial: z.enum(statutsSociaux).nullish(),
   notes: optional(Notes.schema),
 })


### PR DESCRIPTION
La règle « tranche toujours dérivée de l'année de naissance » posée au refacto contredisait le formulaire, qui permet la saisie manuelle : la tranche saisie sans année était perdue à la création et effacée à la modification. L'année reste prioritaire ; sans année, la saisie fait foi. Le champ traverse désormais form shape → validations → domaine (créer, modifier, importer).

La normalisation canonique E.164 (voulue au stockage) était réaffichée brute : telephoneDisplayString rend le format national par paires pour la métropole et l'outre-mer, indicatif détaché sinon, et tolère les valeurs legacy non normalisées. Appliqué à la fiche, au préremplissage d'édition, à l'export Excel et à la fusion de doublons.