### PR TITLE
fix(beneficiaire): répare les emails du backfill et fiabilise la norm…

### DIFF
--- a/apps/web/src/features/beneficiaire/abilities/normaliser-beneficiaires/domain/repair-email.spec.ts
+++ b/apps/web/src/features/beneficiaire/abilities/normaliser-beneficiaires/domain/repair-email.spec.ts
@@ -1,0 +1,69 @@
+import { emailAbsent, repairEmail } from './repair-email'
+
+describe('repairEmail', () => {
+  it.each([
+    ['marie@curie.fr', 'marie@curie.fr'], // déjà canonique
+    ['  Marie@Curie.FR ', 'marie@curie.fr'], // bords/casse (via le VO)
+    ['farnesekif@gmail.com;', 'farnesekif@gmail.com'], // ponctuation finale
+    ['rachelceva77@gmail.com>', 'rachelceva77@gmail.com'],
+    ["henrybressolette@msn.com'", 'henrybressolette@msn.com'],
+    ['fes39@outlook.fr\r\nfati@gmail.com', 'fes39@outlook.fr'], // multi retour ligne → 1er
+    ['dussert.Chantal@icloud.com; cjp@free.fr', 'dussert.chantal@icloud.com'], // multi « ; » → 1er
+    ['jptenel@gmail.com - mntenel@gmail.com', 'jptenel@gmail.com'], // multi tiret → 1er
+    ['0646004199 alain.carville01@gmail.com', 'alain.carville01@gmail.com'], // téléphone accolé
+    ['tivoli_2006@yahoo,fr', 'tivoli_2006@yahoo.fr'], // virgule → point
+    ['laurinedenis51@gmail,com', 'laurinedenis51@gmail.com'],
+    ['thlesellier@@laposte.net', 'thlesellier@laposte.net'], // @ dédoublé
+    ['françoisepayet16@gmail.com', 'francoisepayet16@gmail.com'], // accents translittérés
+    ['joélruthjoél@yahoo.fr', 'joelruthjoel@yahoo.fr'],
+    // la translittération rend l'adresse syntaxiquement valide ; le domaine
+    // (typo probable de laposte.net) n'est pas du ressort de la validation
+    ['desirécarlos@lapoace.net', 'desirecarlos@lapoace.net'],
+    ['sœur.paul@hotmail.fr\nsoeur.paul@foyer.fr', 'soeur.paul@hotmail.fr'], // ligature œ
+    ['delyeveline@gmailcom', 'delyeveline@gmail.com'], // point de domaine manquant
+    ['dmouctar461@gmailcom', 'dmouctar461@gmail.com'],
+    ['p.ingouff@gmail', 'p.ingouff@gmail.com'], // TLD manquant (fournisseur non ambigu)
+    ['y.colliard@vert-saint-denis.f', 'y.colliard@vert-saint-denis.fr'], // TLD tronqué .f
+    ['chantval85gmail.com', 'chantval85@gmail.com'], // @ oublié devant un fournisseur
+    ['guehobrigitteicloud.com', 'guehobrigitte@icloud.com'],
+    ['valolioorange.fr', 'valolio@orange.fr'],
+    ['krystynaasatrian99 @gmail.com', 'krystynaasatrian99@gmail.com'], // espace avant @
+    ['lyse .brehaut@neuf.fr', 'lyse.brehaut@neuf.fr'],
+    ['tovichra@yahoo fr', 'tovichra@yahoo.fr'], // espace à la place du point du TLD
+    ['‭corser.cs@gmail.com‬', 'corser.cs@gmail.com'], // caractères invisibles
+  ])('repairs %s to %s', (raw, expected) => {
+    expect(repairEmail(raw)).toBe(expected)
+  })
+
+  it.each([
+    '',
+    'elsabethcuvellier', // pas de @ ni fournisseur connu
+    'A créer', // texte égaré (vidé via emailAbsent, pas réparé)
+    'Pas la bonne @ shem_terry@live.fr', // la note dit que l'adresse est fausse
+    'delyeveline@hotmail', // TLD ambigu (.fr et .com coexistent)
+  ])('returns null for the irrecoverable %s', (raw) => {
+    expect(repairEmail(raw)).toBeNull()
+  })
+})
+
+describe('emailAbsent', () => {
+  it.each([
+    'A créer',
+    'a créer',
+    "pas d'email",
+    "pas d'adresse mail",
+    "pas de mail pour l'instant",
+  ])('detects the absence mention %s', (raw) => {
+    expect(emailAbsent(raw)).toBe(true)
+  })
+
+  it.each([
+    '',
+    'FB',
+    '2etg gauche',
+    'chantval85gmail.com',
+    'marie@curie.fr',
+  ])('leaves %s alone', (raw) => {
+    expect(emailAbsent(raw)).toBe(false)
+  })
+})

--- a/apps/web/src/features/beneficiaire/abilities/normaliser-beneficiaires/domain/repair-email.ts
+++ b/apps/web/src/features/beneficiaire/abilities/normaliser-beneficiaires/domain/repair-email.ts
@@ -1,0 +1,128 @@
+import { Email } from '@app/web/features/beneficiaire/domain/email'
+
+const tryEmail = (value: string): Email | null => {
+  try {
+    return Email(value)
+  } catch {
+    return null
+  }
+}
+
+// Domaines de fournisseurs grand public : servent à réinsérer un point manquant
+// (gmailcom → gmail.com) et un `@` oublié (chantval85gmail.com →
+// chantval85@gmail.com).
+const FOURNISSEURS = [
+  'gmail.com',
+  'yahoo.fr',
+  'yahoo.com',
+  'hotmail.fr',
+  'hotmail.com',
+  'outlook.fr',
+  'outlook.com',
+  'orange.fr',
+  'wanadoo.fr',
+  'free.fr',
+  'neuf.fr',
+  'sfr.fr',
+  'skynet.be',
+  'icloud.com',
+  'live.fr',
+  'live.com',
+  'laposte.net',
+  'proton.me',
+  'aol.com',
+  'msn.com',
+]
+
+// Domaines sans point réparables sans ambiguïté, plus les TLD absents quand une
+// seule forme existe (gmail → gmail.com ; pas hotmail/outlook nus : .fr et
+// .com coexistent).
+const DOMAINE_REPARE: Record<string, string> = {
+  gmail: 'gmail.com',
+  ...Object.fromEntries(
+    FOURNISSEURS.map((domaine) => [domaine.replace(/\./g, ''), domaine]),
+  ),
+}
+
+const avecDomaineRepare = (email: string): string => {
+  const parts = email.split('@')
+  if (parts.length !== 2) return email
+  const [local, domaine] = parts
+  const repare = DOMAINE_REPARE[domaine.toLowerCase()]
+  return repare ? `${local}@${repare}` : email
+}
+
+const avecArobaseInseree = (value: string): string => {
+  if (value.includes('@')) return value
+  const fournisseur = FOURNISSEURS.find(
+    (domaine) =>
+      value.toLowerCase().endsWith(domaine) && value.length > domaine.length,
+  )
+  return fournisseur
+    ? `${value.slice(0, -fournisseur.length)}@${fournisseur}`
+    : value
+}
+
+// Les fournisseurs n'acceptant pas les caractères accentués, l'adresse réelle
+// est la forme ASCII (françoise → francoise, sœur → soeur).
+const sansAccents = (value: string): string =>
+  value
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/œ/g, 'oe')
+    .replace(/Œ/g, 'OE')
+    .replace(/æ/g, 'ae')
+    .replace(/Æ/g, 'AE')
+
+/**
+ * Répare un email stocké potentiellement abîmé vers sa forme canonique
+ * (minuscules, sans bords), ou `null` si irrécupérable. Candidats essayés dans
+ * l'ordre :
+ *  1. tel quel (déjà valide / canonique) ;
+ *  2. le 1er token contenant `@` — champs multi-adresses séparées par retour à
+ *     la ligne, « ; » ou espace, texte ou téléphone accolé ;
+ *  3. ponctuation finale parasite retirée (`;`, `'`, `>`…) ;
+ *  4. virgule tapée à la place du point (`@yahoo,fr`) ;
+ *  5. `@` dédoublé ramené à un seul (`thlesellier@@laposte.net`) ;
+ *  6. accents translittérés (`françoise@` → `francoise@`) ;
+ *  7. domaine connu réparé (`@gmailcom`, `@gmail` → `@gmail.com`) ;
+ *  8. TLD tronqué `.f` complété en `.fr` ;
+ *  9. `@` restitué devant un fournisseur connu (`chantval85gmail.com`) ;
+ * 10. espaces internes retirés (`lyse .brehaut@`, `…99 @gmail.com`) ;
+ * 11. espace tapé à la place du point du TLD (`tovichra@yahoo fr`).
+ * Les caractères invisibles (contrôle/format Unicode) sont retirés d'emblée.
+ *
+ * Réservé au backfill : le value object `Email` reste strict pour les saisies
+ * utilisateur (une adresse abîmée doit y être rejetée, pas réparée).
+ */
+export const repairEmail = (raw: string): Email | null => {
+  const visible = raw.replace(/\p{Cf}/gu, '')
+  const premier =
+    visible.split(/[\s;]+/).find((part) => part.includes('@')) ?? visible
+  const candidates = [
+    visible,
+    premier,
+    premier.replace(/[^a-z0-9]+$/i, ''),
+    premier.replace(/,/g, '.'),
+    premier.replace(/@@+/g, '@'),
+    sansAccents(premier),
+    avecDomaineRepare(premier),
+    premier.replace(/\.f$/i, '.fr'),
+    avecArobaseInseree(premier),
+    visible.replace(/\s+/g, ''),
+    visible.replace(/^(\S+@\S+)\s+([a-z]{2,3})$/i, '$1.$2'),
+  ]
+
+  return candidates.reduce<Email | null>(
+    (found, candidate) => found ?? tryEmail(candidate),
+    null,
+  )
+}
+
+// Mentions d'absence d'adresse (« A créer », « pas d'email », « pas d'adresse
+// mail », « pas de mail pour l'instant ») — à vider, pas à conserver en erreur.
+const MENTIONS_ABSENCE = [/^a créer$/i, /^pas d['e ].*mail/i]
+
+/** Mention « pas d'adresse » saisie à la place d'un email — à vider. */
+export const emailAbsent = (raw: string): boolean =>
+  MENTIONS_ABSENCE.some((mention) => mention.test(raw.trim()))

--- a/apps/web/src/features/beneficiaire/abilities/normaliser-beneficiaires/domain/repair-telephone.spec.ts
+++ b/apps/web/src/features/beneficiaire/abilities/normaliser-beneficiaires/domain/repair-telephone.spec.ts
@@ -1,4 +1,4 @@
-import { repairTelephone } from './repair-telephone'
+import { repairTelephone, telephonePlaceholder } from './repair-telephone'
 
 describe('repairTelephone', () => {
   it.each([
@@ -8,9 +8,13 @@ describe('repairTelephone', () => {
     ['745298688', '+33745298688'], // 0 de tête manquant (9 chiffres)
     ['0651764142 / 0782950623', '+33651764142'], // multi « / » → 1er
     ['02.41.32.50.21\r\n06.21.76.22.27', '+33241325021'], // multi retour ligne → 1er
+    ['02 31 20 32 78 ou 06 62 62 39 90', '+33231203278'], // multi « ou » → 1er
     ['00604417500', '+33604417500'], // 00 parasite → national
     ['+2620692344650', '+262692344650'], // 0 redondant après +262
     ['00352621365161', '+352621365161'], // Luxembourg (via le VO)
+    ['++352 621 797 965', '+352621797965'], // + dédoublé
+    ['33769592540', '+33769592540'], // international sans son +
+    ['352 621 315 354', '+352621315354'], // idem, Luxembourg
   ])('repairs %s to %s', (raw, expected) => {
     expect(repairTelephone(raw)).toBe(expected)
   })
@@ -22,7 +26,30 @@ describe('repairTelephone', () => {
     '0041779494741', // étranger
     '664', // trop court
     'RelaisNumérique', // texte
+    '065295998', // 9 chiffres commençant par 0 : chiffre manquant, pas le 0 de tête
+    '068?652866', // chiffre illisible
+    '0000000000', // placeholder (vidé via telephonePlaceholder, pas réparé)
   ])('returns null for the irrecoverable %s', (raw) => {
     expect(repairTelephone(raw)).toBeNull()
+  })
+})
+
+describe('telephonePlaceholder', () => {
+  it.each([
+    '0000000000',
+    '00 00 00 00 00',
+    '0.0.0.0',
+  ])('detects the placeholder %s', (raw) => {
+    expect(telephonePlaceholder(raw)).toBe(true)
+  })
+
+  it.each([
+    '0601020304',
+    '-',
+    '',
+    'aucun',
+    '00 00 00 00 01',
+  ])('leaves %s alone', (raw) => {
+    expect(telephonePlaceholder(raw)).toBe(false)
   })
 })

--- a/apps/web/src/features/beneficiaire/abilities/normaliser-beneficiaires/domain/repair-telephone.ts
+++ b/apps/web/src/features/beneficiaire/abilities/normaliser-beneficiaires/domain/repair-telephone.ts
@@ -12,33 +12,52 @@ const tryTelephone = (value: string): Telephone | null => {
 // redondant écrit juste après l'indicatif (ex. +262 0692… → +262 692…).
 const KNOWN_PREFIX = /^(\+(?:33|262|352|590|594|596))0/
 
+// Numéro international saisi sans son « + » : indicatif connu + 9 chiffres
+// (ex. 33769592540, 352 621 315 354).
+const SANS_PLUS = /^(?:33|262|352|590|594|596)\d{9}$/
+
 /**
  * Répare un téléphone stocké potentiellement abîmé vers sa forme canonique
  * (international), ou `null` si irrécupérable. Candidats essayés dans l'ordre :
  *  1. tel quel (déjà valide / canonique) ;
- *  2. le 1er numéro — champs multi-numéros séparés par retour à la ligne ou
- *     « / » — compacté (espaces et séparateurs parasites retirés) ;
- *  3. `00` de tête ramené à `0` (0 parasite : `00604…` → `0604…`) ;
- *  4. 0 de jonction redondant retiré après un indicatif connu (`+2620692…`) ;
- *  5. avec un 0 de tête, pour un numéro à 9 chiffres saisi sans son 0.
+ *  2. le 1er numéro — champs multi-numéros séparés par retour à la ligne,
+ *     « / » ou « ou » — compacté (espaces et séparateurs parasites retirés) ;
+ *  3. « + » dédoublé ramené à un seul (++352… → +352…) ;
+ *  4. `00` de tête ramené à `0` (0 parasite : `00604…` → `0604…`) ;
+ *  5. 0 de jonction redondant retiré après un indicatif connu (`+2620692…`) ;
+ *  6. « + » restitué devant un indicatif connu suivi de 9 chiffres
+ *     (`33769592540` → `+33769592540`) ;
+ *  7. avec un 0 de tête, pour un numéro à 9 chiffres saisi sans son 0 (sauf
+ *     s'il commence déjà par 0 : il lui manque un chiffre, pas son préfixe).
  *
  * Réservé au backfill : le value object `Telephone` reste strict pour les
  * saisies utilisateur (un numéro abîmé doit y être rejeté, pas réparé).
  */
 export const repairTelephone = (raw: string): Telephone | null => {
-  const first = raw.split(/[\r\n/]+/)[0] ?? raw
+  const first = raw.split(/[\r\n/]+|\s+ou\s+/i)[0] ?? raw
   const compact = first.replace(/[^\d+]/g, '')
   const digits = first.replace(/\D/g, '')
   const candidates = [
     raw,
     compact,
+    compact.replace(/^\++/, '+'),
     compact.replace(/^00/, '0'),
     compact.replace(KNOWN_PREFIX, '$1'),
-    ...(digits.length === 9 ? [`0${digits}`] : []),
+    ...(SANS_PLUS.test(digits) ? [`+${digits}`] : []),
+    ...(digits.length === 9 && !digits.startsWith('0') ? [`0${digits}`] : []),
   ]
 
   return candidates.reduce<Telephone | null>(
     (found, candidate) => found ?? tryTelephone(candidate),
     null,
   )
+}
+
+/**
+ * Placeholder « pas de numéro » : uniquement des zéros (avec ou sans
+ * séparateurs : `0000000000`, `00 00 00 00 00`) — à vider, pas à réparer.
+ */
+export const telephonePlaceholder = (raw: string): boolean => {
+  const digits = raw.replace(/\D/g, '')
+  return digits.length > 0 && /^0+$/.test(digits)
 }

--- a/apps/web/src/features/beneficiaire/abilities/normaliser-beneficiaires/implementation/prisma/normaliser-beneficiaires.mutation.ts
+++ b/apps/web/src/features/beneficiaire/abilities/normaliser-beneficiaires/implementation/prisma/normaliser-beneficiaires.mutation.ts
@@ -9,7 +9,11 @@ import type {
   NormaliserBeneficiaireError,
   NormaliserBeneficiaires,
 } from '../../domain/normaliser-beneficiaires'
-import { repairTelephone } from '../../domain/repair-telephone'
+import { emailAbsent, repairEmail } from '../../domain/repair-email'
+import {
+  repairTelephone,
+  telephonePlaceholder,
+} from '../../domain/repair-telephone'
 
 const BATCH_SIZE = 100
 const MAX_REPORTED_ERRORS = 100
@@ -18,23 +22,34 @@ type BeneficiaireRow = Awaited<
   ReturnType<typeof prismaClient.beneficiaire.findMany>
 >[number]
 
-// Téléphone à stocker : réparé si possible ; sinon vidé (`null`) si la valeur
+// Téléphone / email à stocker : réparé si possible ; sinon vidé (`null`) si la
+// valeur est un placeholder (« 0000000000 », « A créer », « pas d'email »…) ou
 // n'a aucun caractère alphanumérique (« - », « / »… = purement séparateurs) ;
-// sinon laissée telle quelle (la fiche sera sautée et remontée dans les erreurs,
-// y compris un texte égaré que l'on ne veut pas détruire).
-const telephoneToStore = (raw: string): string | null =>
-  repairTelephone(raw) ?? (/[a-z0-9]/i.test(raw) ? raw : null)
+// sinon laissée telle quelle (la fiche sera sautée et remontée dans les
+// erreurs, y compris un texte égaré que l'on ne veut pas détruire).
+const irrecuperableToStore = (raw: string): string | null =>
+  /[a-z0-9]/i.test(raw) ? raw : null
 
-// Re-canonicalise une fiche via le transfer layer (téléphone pré-réparé).
-// `modification` est réémis pour que l'extension timestamp ne bumpe pas (un
-// nettoyage de données n'est pas une édition). Une donnée invalide fait throw
-// toDomain → la fiche est remontée dans les erreurs.
+const telephoneToStore = (raw: string): string | null =>
+  repairTelephone(raw) ??
+  (telephonePlaceholder(raw) ? null : irrecuperableToStore(raw))
+
+const emailToStore = (raw: string): string | null =>
+  repairEmail(raw) ?? (emailAbsent(raw) ? null : irrecuperableToStore(raw))
+
+// Re-canonicalise une fiche via le transfer layer (téléphone et email
+// pré-réparés). `modification` est réémis pour que l'extension timestamp ne
+// bumpe pas (un nettoyage de données n'est pas une édition). Une donnée
+// invalide fait throw toDomain → la fiche est remontée dans les erreurs.
 const recanonicalise = (row: BeneficiaireRow) => {
   try {
-    const prepared =
-      row.telephone === null
-        ? row
-        : { ...row, telephone: telephoneToStore(row.telephone) }
+    const prepared = {
+      ...row,
+      ...(row.telephone === null
+        ? {}
+        : { telephone: telephoneToStore(row.telephone) }),
+      ...(row.email === null ? {} : { email: emailToStore(row.email) }),
+    }
     const { id: _id, ...rest } = beneficiaireFromDomain(
       beneficiaireToDomain(prepared),
     )

--- a/apps/web/src/features/beneficiaire/abilities/normaliser-beneficiaires/normaliser-beneficiaires.integration.ts
+++ b/apps/web/src/features/beneficiaire/abilities/normaliser-beneficiaires/normaliser-beneficiaires.integration.ts
@@ -10,20 +10,24 @@ import { normaliserBeneficiaires } from './implementation'
 
 const nationalId = v4()
 const emailId = v4()
+const emailAbimeId = v4()
 const communeId = v4()
 const invalidId = v4()
 const canoniqueId = v4()
 const multiId = v4()
 const tiretId = v4()
+const placeholderId = v4()
 
 const ids = [
   nationalId,
   emailId,
+  emailAbimeId,
   communeId,
   invalidId,
   canoniqueId,
   multiId,
   tiretId,
+  placeholderId,
 ]
 
 const oldModification = new Date('2020-01-01T00:00:00.000Z')
@@ -60,6 +64,14 @@ describe('normaliserBeneficiaires', () => {
           prenom: 'Up',
           nom: 'Per',
           email: 'JEAN.DUPONT@EXEMPLE.COM',
+        },
+        {
+          id: emailAbimeId,
+          mediateurId: mediateurAvecActiviteMediateurId,
+          anonyme: false,
+          prenom: 'Ab',
+          nom: 'Ime',
+          email: 'jean.dupont@gmailcom;',
         },
         {
           id: communeId,
@@ -104,6 +116,15 @@ describe('normaliserBeneficiaires', () => {
           nom: 'Vide',
           telephone: '-',
         },
+        {
+          id: placeholderId,
+          mediateurId: mediateurAvecActiviteMediateurId,
+          anonyme: false,
+          prenom: 'Place',
+          nom: 'Holder',
+          telephone: '0000000000',
+          email: 'A créer',
+        },
       ],
     })
 
@@ -116,6 +137,9 @@ describe('normaliserBeneficiaires', () => {
 
     expect((await fiche(emailId)).email).toBe('jean.dupont@exemple.com')
 
+    // réparation câblée dans le backfill (couverture exhaustive : repair-email.spec)
+    expect((await fiche(emailAbimeId)).email).toBe('jean.dupont@gmail.com')
+
     const commune = await fiche(communeId)
     expect(commune.communeCodePostal).toBe('75001')
     expect(commune.communeCodeInsee).toBe('75101')
@@ -125,6 +149,11 @@ describe('normaliserBeneficiaires', () => {
 
     // valeur sans aucun chiffre (« - ») → champ vidé
     expect((await fiche(tiretId)).telephone).toBeNull()
+
+    // placeholders (« 0000000000 », « A créer ») → champs vidés
+    const placeholder = await fiche(placeholderId)
+    expect(placeholder.telephone).toBeNull()
+    expect(placeholder.email).toBeNull()
 
     // invalide : laissé tel quel (sauté, jamais corrompu)
     expect((await fiche(invalidId)).telephone).toBe('pas-un-numero')

--- a/apps/web/src/features/beneficiaire/domain/telephone.ts
+++ b/apps/web/src/features/beneficiaire/domain/telephone.ts
@@ -3,9 +3,10 @@ import { z } from 'zod'
 
 // Indicatifs acceptés : France métropole (33) + outre-mer (262, 590, 594, 596)
 // + Luxembourg (352, zone frontalière). Format national : 10 chiffres commençant
-// par 0. Format international : indicatif + 9 chiffres.
+// par 0 puis 1-9 (jamais 00, réservé au préfixe international). Format
+// international : indicatif + 9 chiffres.
 export const TELEPHONE_PATTERN =
-  /^(?:(?:\(\+(?:33|262|352|590|594|596)\)|\+(?:33|262|352|590|594|596)|00(?:33|262|352|590|594|596))[\s()./-]*(?:\d[\s()./-]*){8}\d|0\d(?:[\s./-]?\d){8})$/
+  /^(?:(?:\(\+(?:33|262|352|590|594|596)\)|\+(?:33|262|352|590|594|596)|00(?:33|262|352|590|594|596))[\s()./-]*(?:\d[\s()./-]*){8}\d|0[1-9](?:[\s./-]?\d){8})$/
 
 // Indicatif pays déduit du préfixe d'un numéro national outre-mer ;
 // à défaut, métropole (33).


### PR DESCRIPTION
Le backfill normaliser-beneficiaires sautait toute fiche dont l'email était abîmé (multi-adresses, @@, accents, domaine sans point ou sans @, TLD tronqué…), laissant en base des téléphones pourtant réparables qui faisaient 500 la liste des bénéficiaires. Un repair-email symétrique de repair-telephone récupère ces adresses, et les mentions d'absence (« A créer », « pas d'email ») comme les placeholders « 0000000000 » sont vidés au lieu de rester en erreur.

Côté téléphone, la réparation restitue le « + » devant un indicatif connu, dédouble les « + », scinde les champs « X ou Y », et ne préfixe plus un 0 de tête sur un numéro qui commence déjà par 0 (chiffre manquant, pas préfixe). La branche nationale du value object Telephone exige désormais 0[1-9] : un numéro tout en zéros passait la regex mais se transformait en +00000000, cassant l'invariant canonique au round-trip.