### PR TITLE
fix(fixtures): refuse le chargement de fixtures ciblant la production

### DIFF
--- a/apps/web/src/assertDatabaseTarget.ts
+++ b/apps/web/src/assertDatabaseTarget.ts
@@ -1,6 +1,11 @@
-// Garde-fou partagé contre l'exécution d'un outil destructif/local contre la PRODUCTION.
+// Garde-fou partagé contre l'exécution d'un outil destructif contre la PRODUCTION.
 // L'hôte n'est PAS un signal fiable (les tunnels prod répondent sur localhost, cf. incident
-// 2026-07-08) : le signal fiable est le NOM de la base cible.
+// 2026-07-08), et un simple motif « prod » non plus : une base de preview nommée d'après la
+// branche peut contenir « prod » (ex. `coop-…-fix-fixtures-load-prod-guard`). Le seul signal
+// fiable est le NOM EXACT de la base, comparé à une liste de bases de production connues.
+
+// Bases de PRODUCTION connues (match exact, insensible à la casse).
+const KNOWN_PRODUCTION_DATABASE_NAMES = ['dataspace_prod']
 
 const databaseNameFromUrl = (databaseUrl: string): string => {
   try {
@@ -22,13 +27,17 @@ export const databaseUrlLooksLikeProduction = (
   databaseUrl: string,
   productionDatabaseName?: string,
 ): boolean => {
-  const target = databaseNameFromUrl(databaseUrl).toLowerCase()
-  const production = (productionDatabaseName ?? '').trim().toLowerCase()
-  return (
-    (production !== '' && target === production) ||
-    /prod/i.test(target) ||
-    /[?&]sslmode=require\b/i.test(databaseUrl)
-  )
+  const target = databaseNameFromUrl(databaseUrl).trim().toLowerCase()
+  if (target === '') {
+    return false
+  }
+  const known = [
+    ...KNOWN_PRODUCTION_DATABASE_NAMES,
+    productionDatabaseName ?? '',
+  ]
+    .map((name) => name.trim().toLowerCase())
+    .filter((name) => name !== '')
+  return known.includes(target)
 }
 
 // Refuse si la cible ressemble à la production, sauf si `confirmProduction` vaut EXACTEMENT

--- a/apps/web/src/assertDatabaseTarget.ts
+++ b/apps/web/src/assertDatabaseTarget.ts
@@ -1,0 +1,69 @@
+// Garde-fou partagé contre l'exécution d'un outil destructif/local contre la PRODUCTION.
+// L'hôte n'est PAS un signal fiable (les tunnels prod répondent sur localhost, cf. incident
+// 2026-07-08) : le signal fiable est le NOM de la base cible.
+
+const databaseNameFromUrl = (databaseUrl: string): string => {
+  try {
+    return new URL(databaseUrl).pathname.split('/')[1] ?? ''
+  } catch {
+    return ''
+  }
+}
+
+const hostFromUrl = (databaseUrl: string): string => {
+  try {
+    return new URL(databaseUrl).hostname
+  } catch {
+    return '(hôte inconnu)'
+  }
+}
+
+export const databaseUrlLooksLikeProduction = (
+  databaseUrl: string,
+  productionDatabaseName?: string,
+): boolean => {
+  const target = databaseNameFromUrl(databaseUrl).toLowerCase()
+  const production = (productionDatabaseName ?? '').trim().toLowerCase()
+  return (
+    (production !== '' && target === production) ||
+    /prod/i.test(target) ||
+    /[?&]sslmode=require\b/i.test(databaseUrl)
+  )
+}
+
+// Refuse si la cible ressemble à la production, sauf si `confirmProduction` vaut EXACTEMENT
+// le nom de la base cible (le passer force à lire et retaper le nom).
+export const assertDatabaseIsNotProduction = ({
+  databaseUrl,
+  productionDatabaseName,
+  confirmProduction,
+  action,
+}: {
+  databaseUrl: string
+  productionDatabaseName?: string
+  confirmProduction?: string
+  action: string
+}): void => {
+  if (!databaseUrlLooksLikeProduction(databaseUrl, productionDatabaseName)) {
+    return
+  }
+
+  const target = databaseNameFromUrl(databaseUrl)
+  const host = hostFromUrl(databaseUrl)
+
+  if (confirmProduction === target && target !== '') {
+    // biome-ignore lint/suspicious/noConsole: garde-fou exécuté en CLI (fixtures/scripts), avertissement volontaire
+    console.warn(
+      `⚠️  ${action} : cible de PRODUCTION confirmée explicitement (${host}/${target})`,
+    )
+    return
+  }
+
+  throw new Error(
+    [
+      `Refus : ${action} vise ce qui ressemble à la PRODUCTION (${host}/${target}).`,
+      "Si c'est réellement voulu, relancez avec :",
+      `  --confirm-production ${target}`,
+    ].join('\n'),
+  )
+}

--- a/packages/fixtures/src/load.ts
+++ b/packages/fixtures/src/load.ts
@@ -1,9 +1,19 @@
 import { output } from '@app/fixtures/output'
 import { deleteAll, seed } from '@app/fixtures/seeds'
+import { assertDatabaseIsNotProduction } from '@app/web/assertDatabaseTarget'
 import { prismaClient } from '@app/web/prismaClient'
 import { Command } from '@commander-js/extra-typings'
 
-const main = async (eraseAllData: boolean) => {
+const main = async (eraseAllData: boolean, confirmProduction?: string) => {
+  // Garde-fou : `fixtures:load` injecte des données de test (et TRUNCATE tout avec `-e`).
+  // Il ne doit JAMAIS s'exécuter contre la production par erreur (cf. incident 2026-07-08).
+  assertDatabaseIsNotProduction({
+    databaseUrl: process.env.DATABASE_URL ?? '',
+    productionDatabaseName: process.env.DATASPACE_BACKUP_DATABASE_NAME,
+    confirmProduction,
+    action: 'Chargement de fixtures',
+  })
+
   if (eraseAllData) {
     output.log('Erasing all data...')
     await deleteAll(prismaClient)
@@ -14,17 +24,22 @@ const main = async (eraseAllData: boolean) => {
   output.log(`Fixtures loaded successfully`)
 }
 
-const program = new Command().option(
-  '-e, --erase-all-data',
-  'Erase all data from the database before seeding',
-  false,
-)
+const program = new Command()
+  .option(
+    '-e, --erase-all-data',
+    'Erase all data from the database before seeding',
+    false,
+  )
+  .option(
+    '--confirm-production <database>',
+    'Confirme explicitement un chargement de fixtures ciblant la production (valeur = nom exact de la base cible)',
+  )
 
 program.parse()
 
-const { eraseAllData } = program.opts()
+const { eraseAllData, confirmProduction } = program.opts()
 
-main(eraseAllData)
+main(eraseAllData, confirmProduction)
   .then(() => prismaClient.$disconnect())
   .catch(async (error) => {
     output.error(error)


### PR DESCRIPTION
pnpm fixtures:load obéit aveuglément à DATABASE_URL : lancé sur la prod, il injecte des données de test (et TRUNCATE toute la base avec -e). Ajoute un garde-fou partagé (assertDatabaseIsNotProduction) qui refuse AVANT tout write quand la base cible ressemble à la production (nom == base de backup, motif /prod/i, ou sslmode=require), sauf --confirm-production <nom_base_cible>. Helper réutilisable dans @app/web (cf. incident 2026-07-08).