### PR TITLE
fix(normaliser-beneficiaires): préserve la résidence, complète les co…

### DIFF
--- a/apps/web/src/external-apis/ban/communeFieldsFromAddress.ts
+++ b/apps/web/src/external-apis/ban/communeFieldsFromAddress.ts
@@ -7,12 +7,14 @@ export type CommuneFields = {
   communeCodeInsee: string
 }
 
+export type ScoredCommuneFields = CommuneFields & { score: number }
+
 // Géocode une adresse texte libre en commune complète (commune + code postal +
-// code INSEE) via la BAN. Helper partagé (aucune dépendance feature) : réutilisé
-// par la synchro/backfill RDVSP et par le port bénéficiaire d'ingestion externe.
-export const communeFieldsFromAddress = async (
+// code INSEE) ET expose le score de correspondance BAN (0–1), pour arbitrer un
+// remplissage sous seuil de confiance. `null` si la BAN ne rend pas les 3 champs.
+export const scoredCommuneFieldsFromAddress = async (
   address: string | null | undefined,
-): Promise<CommuneFields | null> => {
+): Promise<ScoredCommuneFields | null> => {
   if (!address) return null
 
   const feature = await searchAdresse(address)
@@ -25,5 +27,18 @@ export const communeFieldsFromAddress = async (
     commune,
     communeCodePostal: codePostal,
     communeCodeInsee: codeInsee,
+    score: feature.properties.score,
   }
+}
+
+// Helper partagé (aucune dépendance feature) : réutilisé par la synchro/backfill
+// RDVSP et par le port bénéficiaire d'ingestion externe. Ignore le score.
+export const communeFieldsFromAddress = async (
+  address: string | null | undefined,
+): Promise<CommuneFields | null> => {
+  const scored = await scoredCommuneFieldsFromAddress(address)
+  if (!scored) return null
+
+  const { score: _score, ...fields } = scored
+  return fields
 }

--- a/apps/web/src/features/beneficiaire/abilities/normaliser-beneficiaires/domain/normaliser-beneficiaires.ts
+++ b/apps/web/src/features/beneficiaire/abilities/normaliser-beneficiaires/domain/normaliser-beneficiaires.ts
@@ -21,15 +21,22 @@ export type NormaliserBeneficiaireError = {
   readonly reason: string
 }
 
-// Diff téléphone/email d'une fiche qui serait (ou a été) mise à jour, pour
-// inspection — notamment l'impact de l'élargissement de la validation
-// téléphone aux numéros internationaux.
+// Diff téléphone/email/commune d'une fiche qui serait (ou a été) mise à jour,
+// pour inspection — l'impact de l'élargissement de la validation téléphone aux
+// numéros internationaux, et le remplissage de la commune par géocodage BAN.
 export type NormaliserBeneficiaireChange = {
   readonly id: BeneficiaireId
   readonly telephoneAvant: string | null
   readonly telephoneApres: string | null
   readonly emailAvant: string | null
   readonly emailApres: string | null
+  readonly communeAvant: string | null
+  readonly communeApres: string | null
+  readonly adresseAvant: string | null
+  readonly adresseApres: string | null
+  // Noms des colonnes réellement modifiées : plus aucun changement « invisible »,
+  // tout est traçable dans le rapport CSV.
+  readonly champsModifies: ReadonlyArray<string>
 }
 
 export type NormaliserBeneficiairesResult = {

--- a/apps/web/src/features/beneficiaire/abilities/normaliser-beneficiaires/implementation/prisma/normaliser-beneficiaires.mutation.ts
+++ b/apps/web/src/features/beneficiaire/abilities/normaliser-beneficiaires/implementation/prisma/normaliser-beneficiaires.mutation.ts
@@ -1,3 +1,4 @@
+import { scoredCommuneFieldsFromAddress } from '@app/web/external-apis/ban/communeFieldsFromAddress'
 import {
   beneficiaireFromDomain,
   beneficiaireToDomain,
@@ -18,10 +19,25 @@ import {
 
 const BATCH_SIZE = 100
 const MAX_REPORTED_ERRORS = 100
+// Confiance minimale du géocodage BAN pour remplir une commune incomplète.
+const COMMUNE_SCORE_MIN = 0.9
 
 type BeneficiaireRow = Awaited<
   ReturnType<typeof prismaClient.beneficiaire.findMany>
 >[number]
+
+type Normalized = Omit<ReturnType<typeof beneficiaireFromDomain>, 'id'>
+
+type OkOutcome = {
+  status: 'ok'
+  row: BeneficiaireRow
+  normalized: Normalized
+}
+
+type InvalidOutcome = {
+  status: 'invalid'
+  error: NormaliserBeneficiaireError
+}
 
 // Téléphone / email à stocker : réparé si possible ; sinon vidé (`null`) si la
 // valeur est un placeholder (« 0000000000 », « A créer », « pas d'email »…) ou
@@ -38,11 +54,16 @@ const telephoneToStore = (raw: string): string | null =>
 const emailToStore = (raw: string): string | null =>
   repairEmail(raw) ?? (emailAbsent(raw) ? null : irrecuperableToStore(raw))
 
+const communeComplete = (fields: Normalized): boolean =>
+  fields.commune !== null &&
+  fields.communeCodePostal !== null &&
+  fields.communeCodeInsee !== null
+
 // Re-canonicalise une fiche via le transfer layer (téléphone et email
 // pré-réparés). `modification` est réémis pour que l'extension timestamp ne
 // bumpe pas (un nettoyage de données n'est pas une édition). Une donnée
 // invalide fait throw toDomain → la fiche est remontée dans les erreurs.
-const recanonicalise = (row: BeneficiaireRow) => {
+const recanonicalise = (row: BeneficiaireRow): OkOutcome | InvalidOutcome => {
   try {
     const prepared = {
       ...row,
@@ -54,23 +75,21 @@ const recanonicalise = (row: BeneficiaireRow) => {
     const { id: _id, ...rest } = beneficiaireFromDomain(
       beneficiaireToDomain(prepared),
     )
-    const changed = Object.entries(rest).some(
-      ([key, value]) => value !== (row as Record<string, unknown>)[key],
-    )
-    return changed
-      ? {
-          status: 'changed' as const,
-          id: row.id,
-          data: { ...rest, modification: row.modification },
-          change: {
-            id: BeneficiaireId(row.id),
-            telephoneAvant: row.telephone,
-            telephoneApres: rest.telephone ?? null,
-            emailAvant: row.email,
-            emailApres: rest.email ?? null,
-          } satisfies NormaliserBeneficiaireChange,
-        }
-      : { status: 'unchanged' as const }
+    // Le round-trip du domaine ne sait pas représenter une commune INCOMPLÈTE
+    // (trio commune/CP/INSEE partiel) : il la réduit à `null` et efface au
+    // passage l'adresse texte. Normaliser ne doit RIEN supprimer → si le
+    // round-trip nullifie une colonne de résidence, on restitue la valeur
+    // d'origine (`?? row`) ; une commune COMPLÈTE reste canonicalisée (ex. CP
+    // « 75 001 » → « 75001 »). Le remplissage d'un partiel se fait ensuite par
+    // géocodage (cf. `withGeocodedCommune`).
+    const normalized: Normalized = {
+      ...rest,
+      adresse: rest.adresse ?? row.adresse,
+      commune: rest.commune ?? row.commune,
+      communeCodePostal: rest.communeCodePostal ?? row.communeCodePostal,
+      communeCodeInsee: rest.communeCodeInsee ?? row.communeCodeInsee,
+    }
+    return { status: 'ok', row, normalized }
   } catch (error) {
     const reason = error instanceof Error ? error.message : 'erreur inconnue'
     // La validation email marque `"validation": "email"` ; le téléphone est le
@@ -87,7 +106,7 @@ const recanonicalise = (row: BeneficiaireRow) => {
           ? row.telephone
           : null
     return {
-      status: 'invalid' as const,
+      status: 'invalid',
       error: {
         id: BeneficiaireId(row.id),
         champ,
@@ -96,6 +115,62 @@ const recanonicalise = (row: BeneficiaireRow) => {
       } satisfies NormaliserBeneficiaireError,
     }
   }
+}
+
+// Commune INCOMPLÈTE + adresse renseignée → on géocode l'adresse et on remplit
+// le trio commune/CP/INSEE si la BAN matche avec assez de confiance ; sinon on
+// préserve le partiel (jamais d'effacement). Une commune déjà complète ou sans
+// adresse n'appelle pas la BAN.
+const withGeocodedCommune = async (
+  normalized: Normalized,
+): Promise<Normalized> => {
+  if (communeComplete(normalized) || normalized.adresse === null)
+    return normalized
+
+  // Un échec BAN (réseau, quota) ne doit pas avorter la normalisation : on
+  // préserve alors le partiel tel quel.
+  const scored = await scoredCommuneFieldsFromAddress(normalized.adresse).catch(
+    () => null,
+  )
+  return scored && scored.score > COMMUNE_SCORE_MIN
+    ? {
+        ...normalized,
+        commune: scored.commune,
+        communeCodePostal: scored.communeCodePostal,
+        communeCodeInsee: scored.communeCodeInsee,
+      }
+    : normalized
+}
+
+const needsGeocoding = ({ normalized }: OkOutcome): boolean =>
+  !communeComplete(normalized) && normalized.adresse !== null
+
+// Ne retient que les fiches réellement modifiées, avec leur diff (téléphone,
+// email, commune) pour le rapport CSV.
+const toUpdate = ({ row, normalized }: OkOutcome) => {
+  const champsModifies = Object.entries(normalized)
+    .filter(([key, value]) => value !== (row as Record<string, unknown>)[key])
+    .map(([key]) => key)
+  return champsModifies.length > 0
+    ? [
+        {
+          id: row.id,
+          data: { ...normalized, modification: row.modification },
+          change: {
+            id: BeneficiaireId(row.id),
+            telephoneAvant: row.telephone,
+            telephoneApres: normalized.telephone ?? null,
+            emailAvant: row.email,
+            emailApres: normalized.email ?? null,
+            communeAvant: row.commune,
+            communeApres: normalized.commune ?? null,
+            adresseAvant: row.adresse,
+            adresseApres: normalized.adresse ?? null,
+            champsModifies,
+          } satisfies NormaliserBeneficiaireChange,
+        },
+      ]
+    : []
 }
 
 export const normaliserBeneficiaires: NormaliserBeneficiaires = async ({
@@ -110,10 +185,30 @@ export const normaliserBeneficiaires: NormaliserBeneficiaires = async ({
   const errors = outcomes.flatMap((outcome) =>
     outcome.status === 'invalid' ? [outcome.error] : [],
   )
-
-  const aMettreAJour = outcomes.flatMap((outcome) =>
-    outcome.status === 'changed' ? [outcome] : [],
+  const oks = outcomes.flatMap((outcome) =>
+    outcome.status === 'ok' ? [outcome] : [],
   )
+
+  // Seules les communes incomplètes appellent la BAN ; le reste ne fait aucun
+  // I/O réseau. Géocodage séquentiel (doux pour l'API).
+  const geocoded = await oks
+    .filter(needsGeocoding)
+    .reduce<Promise<OkOutcome[]>>(
+      (previous, outcome) =>
+        previous.then(async (list) => [
+          ...list,
+          {
+            ...outcome,
+            normalized: await withGeocodedCommune(outcome.normalized),
+          },
+        ]),
+      Promise.resolve([]),
+    )
+
+  const aMettreAJour = [
+    ...oks.filter((outcome) => !needsGeocoding(outcome)),
+    ...geocoded,
+  ].flatMap(toUpdate)
 
   // Écritures uniquement hors dry-run ; le dry-run se contente de rapporter.
   await (dryRun

--- a/apps/web/src/features/beneficiaire/abilities/normaliser-beneficiaires/normaliser-beneficiaires.integration.ts
+++ b/apps/web/src/features/beneficiaire/abilities/normaliser-beneficiaires/normaliser-beneficiaires.integration.ts
@@ -4,9 +4,19 @@ import {
   mediateurAvecActivite,
   mediateurAvecActiviteMediateurId,
 } from '@app/fixtures/users/mediateurAvecActivite'
+import { scoredCommuneFieldsFromAddress } from '@app/web/external-apis/ban/communeFieldsFromAddress'
 import { prismaClient } from '@app/web/prismaClient'
 import { v4 } from 'uuid'
 import { normaliserBeneficiaires } from './implementation'
+
+jest.mock('@app/web/external-apis/ban/communeFieldsFromAddress', () => ({
+  scoredCommuneFieldsFromAddress: jest.fn(),
+  communeFieldsFromAddress: jest.fn(),
+}))
+
+const mockedScored = scoredCommuneFieldsFromAddress as jest.MockedFunction<
+  typeof scoredCommuneFieldsFromAddress
+>
 
 const nationalId = v4()
 const emailId = v4()
@@ -18,6 +28,7 @@ const multiId = v4()
 const tiretId = v4()
 const placeholderId = v4()
 const dryRunId = v4()
+const communePartielleId = v4()
 
 const ids = [
   nationalId,
@@ -30,6 +41,7 @@ const ids = [
   tiretId,
   placeholderId,
   dryRunId,
+  communePartielleId,
 ]
 
 const oldModification = new Date('2020-01-01T00:00:00.000Z')
@@ -42,6 +54,13 @@ describe('normaliserBeneficiaires', () => {
     await seedStructures(prismaClient)
     await resetFixtureUser(mediateurAvecActivite, false)
   }, 100_000)
+
+  beforeEach(() => {
+    // Par défaut la BAN ne résout rien : les fiches à commune partielle sont
+    // préservées telles quelles (aucun appel réseau réel dans les tests).
+    mockedScored.mockReset()
+    mockedScored.mockResolvedValue(null)
+  })
 
   afterEach(async () => {
     await prismaClient.beneficiaire.deleteMany({ where: { id: { in: ids } } })
@@ -196,5 +215,70 @@ describe('normaliserBeneficiaires', () => {
     const change = result.changes.find((c) => c.id === dryRunId)
     expect(change?.telephoneAvant).toBe('0601020304')
     expect(change?.telephoneApres).toBe('+33601020304')
+    // le rapport nomme les colonnes modifiées : aucun changement « invisible »
+    expect(change?.champsModifies).toContain('telephone')
+  }, 60_000)
+
+  test('fills a partial commune by geocoding when BAN matches confidently', async () => {
+    mockedScored.mockImplementation(async (address) =>
+      address === '12 rue de la Paix'
+        ? {
+            commune: 'Évreux',
+            communeCodePostal: '27000',
+            communeCodeInsee: '27229',
+            score: 0.97,
+          }
+        : null,
+    )
+
+    await prismaClient.beneficiaire.create({
+      data: {
+        id: communePartielleId,
+        mediateurId: mediateurAvecActiviteMediateurId,
+        anonyme: false,
+        prenom: 'Par',
+        nom: 'Tielle',
+        adresse: '12 rue de la Paix',
+        commune: null,
+        communeCodePostal: null,
+        communeCodeInsee: null,
+      },
+    })
+
+    await normaliserBeneficiaires({ dryRun: false })
+
+    const remplie = await fiche(communePartielleId)
+    expect(remplie.adresse).toBe('12 rue de la Paix')
+    expect(remplie.commune).toBe('Évreux')
+    expect(remplie.communeCodePostal).toBe('27000')
+    expect(remplie.communeCodeInsee).toBe('27229')
+  }, 60_000)
+
+  test('preserves a partial commune (never erases) when BAN is uncertain', async () => {
+    // Commune INCOMPLÈTE (INSEE manquant, adresse texte seule) que la BAN ne
+    // résout pas : on ne nullifie ni la commune ni l'adresse.
+    mockedScored.mockResolvedValue(null)
+
+    await prismaClient.beneficiaire.create({
+      data: {
+        id: communePartielleId,
+        mediateurId: mediateurAvecActiviteMediateurId,
+        anonyme: false,
+        prenom: 'Par',
+        nom: 'Tielle',
+        adresse: '12 rue introuvable',
+        commune: 'Évreux',
+        communeCodePostal: '27000',
+        communeCodeInsee: null,
+      },
+    })
+
+    await normaliserBeneficiaires({ dryRun: false })
+
+    const preservee = await fiche(communePartielleId)
+    expect(preservee.adresse).toBe('12 rue introuvable')
+    expect(preservee.commune).toBe('Évreux')
+    expect(preservee.communeCodePostal).toBe('27000')
+    expect(preservee.communeCodeInsee).toBeNull()
   }, 60_000)
 })

--- a/apps/web/src/jobs/normaliser-beneficiaires/executeNormaliserBeneficiaires.ts
+++ b/apps/web/src/jobs/normaliser-beneficiaires/executeNormaliserBeneficiaires.ts
@@ -15,6 +15,11 @@ const csvHeader = [
   'telephone_apres',
   'email_avant',
   'email_apres',
+  'commune_avant',
+  'commune_apres',
+  'adresse_avant',
+  'adresse_apres',
+  'champs_modifies',
 ].join(';')
 
 const changeToCsv = (change: NormaliserBeneficiaireChange): string =>
@@ -24,6 +29,11 @@ const changeToCsv = (change: NormaliserBeneficiaireChange): string =>
     escapeCsvField(change.telephoneApres ?? ''),
     escapeCsvField(change.emailAvant ?? ''),
     escapeCsvField(change.emailApres ?? ''),
+    escapeCsvField(change.communeAvant ?? ''),
+    escapeCsvField(change.communeApres ?? ''),
+    escapeCsvField(change.adresseAvant ?? ''),
+    escapeCsvField(change.adresseApres ?? ''),
+    escapeCsvField(change.champsModifies.join(',')),
   ].join(';')
 
 // CSV des fiches sautées : le champ fautif et sa valeur, pour triage manuel.


### PR DESCRIPTION
Le round-trip du domaine réduisait une commune incomplète (trio commune/CP/INSEE partiel) à null, effaçant au passage l'adresse texte. Désormais :

- les colonnes de résidence nullifiées par le round-trip sont restituées (jamais d'effacement) ; une commune complète reste canonicalisée ;
- une commune incomplète avec adresse est complétée par géocodage BAN si le score dépasse 0,90, sinon préservée ; un échec BAN est toléré (préserve, n'avorte pas) ;
- le rapport CSV nomme les champs modifiés et trace commune/adresse avant/après — plus aucun changement invisible.