### PR TITLE
feat(accueil): alerte de reconnexion RDVSP quand l'intégration est en erreur

### DIFF
--- a/apps/web/src/app/coop/(sidemenu-layout)/(accueil-coop)/Accueil.tsx
+++ b/apps/web/src/app/coop/(sidemenu-layout)/(accueil-coop)/Accueil.tsx
@@ -13,6 +13,7 @@ import {
   ActionsRapides,
   InformationsCoop,
   OnboardingInfo,
+  RdvIntegrationErreurAlerte,
   Support,
 } from './_components'
 import { Equipe } from './_components/Equipe'
@@ -32,6 +33,7 @@ export const Accueil = ({
   timezone,
   userId,
   rdvs,
+  rdvIntegrationStatus,
 }: {
   userId: string
   firstName: string | null
@@ -76,6 +78,11 @@ export const Accueil = ({
             user={{ id: userId, timezone }}
             syncDataOnLoad={rdvs.syncDataOnLoad}
           />
+        </section>
+      )}
+      {!rdvs && rdvIntegrationStatus === 'error' && (
+        <section className="fr-my-6w">
+          <RdvIntegrationErreurAlerte />
         </section>
       )}
       {isCoordinateur && (

--- a/apps/web/src/app/coop/(sidemenu-layout)/(accueil-coop)/_components/RdvIntegrationErreurAlerte.tsx
+++ b/apps/web/src/app/coop/(sidemenu-layout)/(accueil-coop)/_components/RdvIntegrationErreurAlerte.tsx
@@ -1,0 +1,34 @@
+import {
+  rdvOauthLinkAccountErrorCallbackPath,
+  rdvOauthLinkAccountFlowUrl,
+  rdvOauthLinkAccountSuccessCallbackPath,
+} from '@app/web/rdv-service-public/rdvServicePublicOauth'
+import Alert from '@codegouvfr/react-dsfr/Alert'
+import Button from '@codegouvfr/react-dsfr/Button'
+import React from 'react'
+
+export const RdvIntegrationErreurAlerte = () => (
+  <Alert
+    severity="warning"
+    title="Connexion à RDV Service Public expirée"
+    description={
+      <span className="fr-flex fr-direction-column fr-align-items-start fr-flex-gap-3v fr-mt-1v">
+        Vos rendez-vous ne se synchronisent plus avec La Coop.
+        <br />
+        Reconnectez-vous avec votre compte RDV Service Public habituel pour
+        rétablir la synchronisation.
+        <Button
+          size="small"
+          linkProps={{
+            href: rdvOauthLinkAccountFlowUrl({
+              redirectToSuccess: rdvOauthLinkAccountSuccessCallbackPath,
+              redirectToError: rdvOauthLinkAccountErrorCallbackPath,
+            }),
+          }}
+        >
+          Rétablir la synchronisation
+        </Button>
+      </span>
+    }
+  />
+)

--- a/apps/web/src/app/coop/(sidemenu-layout)/(accueil-coop)/_components/index.ts
+++ b/apps/web/src/app/coop/(sidemenu-layout)/(accueil-coop)/_components/index.ts
@@ -1,4 +1,5 @@
 export * from './ActionsRapides'
 export * from './InformationsCoop'
 export * from './OnboardingInfo'
+export * from './RdvIntegrationErreurAlerte'
 export * from './Support'

--- a/apps/web/src/app/coop/(sidemenu-layout)/(accueil-coop)/getAccueilPageDataFor.ts
+++ b/apps/web/src/app/coop/(sidemenu-layout)/(accueil-coop)/getAccueilPageDataFor.ts
@@ -131,6 +131,7 @@ export const getAccueilPageDataFor = async (
     mediateurs,
     activites,
     rdvs: dashboardRdvData,
+    rdvIntegrationStatus: getRdvOauthIntegrationStatus({ user }),
     activitesCoordinationByQuarter,
     syncDataOnLoad: dashboardRdvData ? dashboardRdvData.syncDataOnLoad : false,
   }


### PR DESCRIPTION
Quand le token RDVSP est expiré/révoqué, la synchro pose rdv_accounts.error, ce qui fait renvoyer null à getDashboardRdvDataFor : la section RDV de l'accueil était alors purement omise (aucun widget, aucun message). L'utilisateur ne voyait donc rien alors que ses RDV restaient accessibles dans mes-activites.

Expose rdvIntegrationStatus depuis getAccueilPageDataFor pour préserver la distinction none/error, et affiche une alerte DSFR + bouton de reconnexion (flux OAuth direct) quand l'intégration est en erreur.