### PR TITLE
fix(e2e): couvre les deux parcours ProConnect possibles

### DIFF
--- a/packages/e2e/cypress/e2e/authentication/existingUserCanSigninAndSignout.cy.ts
+++ b/packages/e2e/cypress/e2e/authentication/existingUserCanSigninAndSignout.cy.ts
@@ -6,14 +6,26 @@ describe('ETQ Utilisateur, je peux me connecter à mon compte / me déconnecter 
    * Parcours https://www.figma.com/file/4wfmwOaKRnMhgiGEF256qS/La-Base---Parcours-utilisateurs?node-id=38%3A1135&t=mLwaw4Kkwt7FG9lz-1
    */
 
-  // Cet utilisateur existe chez ProConnect, pas dans notre base. Le prénom et le
-  // nom ne sont pas les nôtres : ils viennent de l'identité que rend le
-  // fournisseur d'identité simulé de l'environnement d'intégration.
+  // Cet utilisateur existe chez ProConnect, pas dans notre base.
+  //
+  // Sur `fca.integ01.dev-agentconnect.fr`, le parcours qui suit la saisie de l'email dépend
+  // du compte de test fourni par l'environnement, et les deux variantes coexistent :
+  //
+  //  - fournisseur d'identité simulé (`test-idp.proconnect.gouv.fr`) : aucun mot de passe,
+  //    aucune sélection d'organisation, et une identité fixe « John Doe » ;
+  //  - `identite-sandbox.proconnect.gouv.fr` : mot de passe puis choix de l'organisation,
+  //    avec l'identité propre au compte.
+  //
+  // Le poste de développement et la CI n'utilisent pas le même compte : décrire un seul des
+  // deux parcours fait échouer l'autre. Le test les couvre donc tous les deux, en se
+  // branchant sur l'URL atteinte, jusqu'à ce que les deux environnements soient alignés.
   const proConnectUser = {
     email: Cypress.env('PROCONNECT_TEST_USER_EMAIL') as string,
-    firstName: 'John',
-    lastName: 'Doe',
+    password: Cypress.env('PROCONNECT_TEST_USER_PASSWORD') as string,
   }
+
+  const identiteFournisseurSimule = { firstName: 'John', lastName: 'Doe' }
+  const identiteSandbox = { firstName: 'Jean', lastName: 'User' }
 
   before(() => {
     cy.execute('deleteUser', { email: proConnectUser.email })
@@ -54,14 +66,23 @@ describe('ETQ Utilisateur, je peux me connecter à mon compte / me déconnecter 
 
     cy.get('#email-input').type(`${proConnectUser.email}{enter}`)
 
-    // ProConnect ne demande plus de mot de passe sur l'environnement d'intégration :
-    // le parcours aboutit sur un fournisseur d'identité simulé, où l'on confirme
-    // l'identité (email, sub, niveau ACR) d'un simple clic.
-    cy.url().should('contain', 'test-idp.proconnect.gouv.fr')
-    cy.contains('button', 'Se connecter').click()
+    // Renseignée dans le branchement ci-dessous, puis lue au moment des assertions
+    // d'identité — jamais à l'empilement des commandes Cypress.
+    let identiteAttendue = identiteFournisseurSimule
 
-    // Plus de sélection d'organisation à faire : le fournisseur d'identité simulé
-    // rend une identité unique, et le rappel nous ramène directement dans l'app.
+    cy.url().then((url) => {
+      if (url.includes('test-idp.proconnect.gouv.fr')) {
+        // Fournisseur d'identité simulé : on confirme l'identité (email, sub, niveau ACR)
+        // d'un simple clic, et il n'y a pas d'organisation à choisir.
+        cy.contains('button', 'Se connecter').click()
+        return
+      }
+
+      // identite-sandbox : mot de passe, puis sélection de l'organisation.
+      identiteAttendue = identiteSandbox
+      cy.get('#password-input').type(`${proConnectUser.password}{enter}`)
+      cy.get('.fr-tile__link').first().click()
+    })
 
     // Cookies are lost in redirect (Cypress issue)
     // https://github.com/cypress-io/cypress/issues/20476#issuecomment-1298486439
@@ -74,10 +95,16 @@ describe('ETQ Utilisateur, je peux me connecter à mon compte / me déconnecter 
 
     cy.dsfrShouldBeStarted()
     cy.dsfrCollapsesShouldBeBound()
-    cy.get('.fr-header__tools button[aria-controls="header-user-menu"]')
-      .contains(proConnectUser.firstName)
-      .contains(proConnectUser.lastName)
-      .click()
+    // `identiteAttendue` est lue ici, à l'exécution : la référencer directement en argument
+    // de `.contains()` la figerait à sa valeur d'avant le branchement.
+    cy.get('.fr-header__tools button[aria-controls="header-user-menu"]').then(
+      ($menu) => {
+        cy.wrap($menu)
+          .contains(identiteAttendue.firstName)
+          .contains(identiteAttendue.lastName)
+          .click()
+      },
+    )
 
     cy.get('#header-user-menu').should('be.visible')
 


### PR DESCRIPTION
## Le problème

`test_web_e2e` échoue sur `dev` **depuis le merge de #582**. Avant celui-ci, seul `chromatic` était rouge — je l'ai vérifié sur le commit précédent (`ce406004`).

La PR #582 embarquait, par cherry-pick, le correctif ProConnect écrit dans #575. Ce correctif est juste — mais pour l'environnement contre lequel il a été écrit.

```
AssertionError: expected 'https://identite-sandbox.proconnect.gouv.fr/users/sign-in'
to include 'test-idp.proconnect.gouv.fr'
   existingUserCanSigninAndSignout.cy.ts:60
```

## Le diagnostic

L'assertion de hostname en amont (`fca.integ01.dev-agentconnect.fr`, ligne 48) **passe en CI**. La plateforme ProConnect est donc bien la même des deux côtés : ce n'est pas un problème de configuration d'environnement.

Ce qui diffère, c'est le **compte de test**. `PROCONNECT_TEST_USER_EMAIL` n'a pas la même valeur sur un poste de développement et en CI, et ProConnect route l'un vers le fournisseur d'identité simulé, l'autre vers `identite-sandbox` :

| | fournisseur simulé | identite-sandbox |
|---|---|---|
| Mot de passe | non | **oui** |
| Choix de l'organisation | non | **oui** |
| Identité rendue | « John Doe » fixe | celle du compte |

Un indice le confirmait : la CI continue d'injecter `CYPRESS_PROCONNECT_TEST_USER_PASSWORD`, dont le correctif précédent ne se servait plus.

## Ce que fait cette PR

Le test se branche sur l'URL atteinte après la saisie de l'email et couvre les deux parcours, y compris la différence d'identité attendue.

Un détail mérite l'attention en relecture : l'identité attendue est lue **dans un `.then()`**, à l'exécution. La passer directement en argument de `.contains()` la figerait à sa valeur d'avant le branchement, puisque Cypress empile les commandes avant de les exécuter — c'est le piège classique, et il aurait rendu le test vert sur un seul des deux parcours.

## Ce que cette PR ne fait pas

Elle ne règle pas la cause. **Un test qui décrit deux parcours en dit moins qu'un test qui en décrit un.** À terme il faut aligner les comptes de test des deux environnements — ce qui suppose d'arbitrer lequel doit faire foi, décision qui ne m'appartient pas. Les deux valeurs sont lisibles en trente secondes dans les réglages CircleCI du projet.

D'ici là, `dev` redevient vert, et #575 bénéficie du même correctif.

## Vérification

`tsc` et `biome` du paquet `@app/e2e` passent. Le parcours lui-même n'est pas rejouable localement — il demande ProConnect et le serveur en `IS_E2E=true` — donc **c'est la CI de cette PR qui fait foi**, et c'est elle qu'il faut regarder avant de merger.