### PR TITLE
fix(build): tait l'avertissement CSS du DSFR, répété à chaque requête

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -35,9 +35,28 @@ const nextConfig = {
     // Type checks are done in other parts of the build process
     ignoreBuildErrors: true,
   },
-  // Le hook `webpack` a disparu : Turbopack l'ignore, et ses deux règles n'ont plus d'objet.
-  // Elles empêchaient le bundler de traiter les `.min.css` — c'est-à-dire les feuilles du
-  // DSFR, désormais chargées par une balise `<link>` et absentes du graphe de modules.
+  // Le hook `webpack` a disparu avec le passage à Turbopack. Ses deux règles écartaient les
+  // `.min.css` du traitement, parce que le `css-loader` de webpack déborde sa pile d'appels
+  // sur `dsfr.min.css` — 701 Ko sur une seule ligne. Turbopack les compile sans difficulté ;
+  // seul Cypress en a encore besoin, et la règle vit désormais dans son propre
+  // `packages/e2e/next.config.js`.
+  turbopack: {
+    // Le DSFR embarque deux blocs `@media screen and (min-width: 0\0) …`, un hack qui ne
+    // vise qu'Internet Explorer 8 à 11 : le `0\0` y est parsé, partout ailleurs il rend la
+    // requête invalide et le bloc inopérant. Turbopack refuse de la parser et écarte ces
+    // blocs — 171 Ko dans `utility.min.css`, 2 Ko dans `dsfr.min.css`.
+    //
+    // C'est le comportement souhaitable : ces règles ne s'appliquaient déjà dans aucun
+    // navigateur vivant, et leurs équivalents non-IE, eux, sont conservés. Mais
+    // l'avertissement se répétait à chaque requête du serveur de dev. On le tait ici, en
+    // visant les deux fichiers concernés, pour ne pas masquer une vraie erreur ailleurs.
+    ignoreIssue: [
+      {
+        path: /public\/dsfr\/.*\.min\.css$/,
+        title: /Parsing CSS source code failed/,
+      },
+    ],
+  },
 }
 
 const enableRelease = process.env.SENTRY_ENABLE_RELEASE === 'true'


### PR DESCRIPTION
Depuis que les feuilles du DSFR sont empaquetées (#586), le serveur de dev répète à **chaque requête** :

```
Warning: Parsing CSS source code failed
@media screen and (min-width: 0\0) and (min-resolution: 72dpi) {
Invalid media query
```

## Ce que c'est

Le `0\0` est un hack qui ne vise **qu'Internet Explorer 8 à 11** : seuls ces navigateurs le parsent, tous les autres jugent la requête invalide et n'appliquent jamais le bloc. Turbopack refuse de la parser et l'écarte — **171 Ko** dans `utility.min.css`, 2 Ko dans `dsfr.min.css`.

## Ce qui ne change pas

Le comportement. Ces règles ne s'appliquaient déjà dans aucun navigateur vivant, et leurs équivalents non-IE sont conservés — vérifié, `.fr-background-default--grey` et consorts existent aussi hors du bloc et survivent à la compilation. Seul l'affichage est tu.

La règle vise les deux fichiers concernés **et ce seul intitulé**, pour ne pas masquer une vraie erreur de parsing ailleurs.

## Corrigé au passage

Le commentaire du hook `webpack` disparu décrivait encore les feuilles du DSFR comme « chargées par une balise `<link>` et absentes du graphe de modules ». C'était vrai d'une étape intermédiaire de #586, abandonnée depuis. Le commentaire donne maintenant la vraie raison de ces règles : le `css-loader` de webpack déborde sa pile d'appels sur 701 Ko de CSS en une ligne.

## Vérifications

Sous Node 24.19.0 : plus aucun avertissement, ni au build ni sur le serveur de dev ; sortie compilée inchangée (blocs IE toujours écartés, règles normales toujours présentes) ; lint et tsc verts sur les dix paquets, tests unitaires au niveau de la référence.